### PR TITLE
Implemented: support to fetch the enums based on parentType

### DIFF
--- a/src/services/UtilService.ts
+++ b/src/services/UtilService.ts
@@ -1,0 +1,13 @@
+import api from "@/api"
+
+const fetchEnums = async (payload: any): Promise<any> => {
+  return api({
+    url: "enums", 
+    method: "GET",
+    params: payload
+  });
+}
+
+export const UtilService = {
+  fetchEnums
+}

--- a/src/store/modules/util/UtilState.ts
+++ b/src/store/modules/util/UtilState.ts
@@ -1,5 +1,9 @@
 import { Enumeration } from "@/types";
 
 export default interface UtilState {
-  enums: Array<Enumeration>
+  enums: {
+    [key: string]: {
+      [key: string]: Enumeration
+    }
+  }
 }

--- a/src/store/modules/util/actions.ts
+++ b/src/store/modules/util/actions.ts
@@ -1,7 +1,37 @@
 import { ActionTree } from "vuex"
 import RootState from "@/store/RootState"
 import UtilState from "./UtilState"
+import logger from "@/logger"
+import { hasError } from "@/utils"
+import * as types from "./mutation-types"
+import { UtilService } from "@/services/UtilService"
+import { EnumerationAndType } from "@/types"
 
-const actions: ActionTree<UtilState, RootState> = {}
+const actions: ActionTree<UtilState, RootState> = {
+  async fetchEnums({ commit }, payload) {
+    let enums = {}
+
+    try {
+      const resp = await UtilService.fetchEnums(payload);
+
+      if(!hasError(resp) && resp.data.length) {
+        enums = resp.data.reduce((enumerations: any, data: EnumerationAndType) => {
+          if(enumerations[data.enumTypeId]) {
+            enumerations[data.enumTypeId][data.enumId] = data
+          } else {
+            enumerations[data.enumTypeId] = {
+              [data.enumId]: data
+            }
+          }
+          return enumerations
+        }, {})
+      }
+    } catch(err) {
+      logger.error('error', err)
+    }
+
+    commit(types.UTIL_ENUMS_UPDATED, enums)
+  }
+}
 
 export default actions;

--- a/src/store/modules/util/index.ts
+++ b/src/store/modules/util/index.ts
@@ -8,7 +8,7 @@ import RootState from "@/store/RootState"
 const utilModule: Module<UtilState, RootState> = {
   namespaced: true,
   state: {
-    enums: [],
+    enums: {},
   },
   getters,
   actions,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,6 +8,12 @@ type Enumeration = {
   sequenceNum: number
 }
 
+type EnumerationAndType = Enumeration & {
+  typeDescription: string,
+  parentTypeId: string,
+  hasTable: string
+}
+
 type Group = {
   routingGroupId: string,
   productStoreId: string,
@@ -46,6 +52,7 @@ type Rule = {
 
 export {
   Enumeration,
+  EnumerationAndType,
   Group,
   Route,
   Rule

--- a/src/views/BrokeringRuns.vue
+++ b/src/views/BrokeringRuns.vue
@@ -54,10 +54,11 @@ import { useStore } from "vuex";
 
 const store = useStore()
 const router = useRouter()
-const groups = computed(() => store.getters['orderRouting/getRoutingGroups'])
+const groups = computed(() => store.getters["orderRouting/getRoutingGroups"])
 
 onIonViewWillEnter(async () => {
-  await store.dispatch('orderRouting/fetchOrderRoutingGroups');
+  await store.dispatch("orderRouting/fetchOrderRoutingGroups");
+  store.dispatch("util/fetchEnums", { parentTypeId: "ORDER_ROUTING" })
 })
 
 async function addNewRun() {


### PR DESCRIPTION
Fetching enums with parentType ORDER_ROUTING
Improved type for enums state
Fetching enums on the initial load of runs page

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/order-routing-rules#contribution-guideline)