### PR TITLE
Fixed: case that on routing page refresh the routing information is not available

### DIFF
--- a/src/services/RoutingService.ts
+++ b/src/services/RoutingService.ts
@@ -1,6 +1,5 @@
 import api from "@/api"
 import logger from "@/logger";
-import store from "@/store";
 import { hasError, showToast } from "@/utils";
 
 const fetchRoutingGroups = async (payload: any): Promise<any> => {
@@ -8,6 +7,13 @@ const fetchRoutingGroups = async (payload: any): Promise<any> => {
     url: "groups", 
     method: "GET",
     query: payload
+  });
+}
+
+const fetchRoutingGroup = async (routingGroupId: string): Promise<any> => {
+  return api({
+    url: `groups/${routingGroupId}`,
+    method: "GET"
   });
 }
 
@@ -109,6 +115,7 @@ export const OrderRoutingService = {
   createRoutingRule,
   fetchOrderRoutings,
   fetchRoutingFilters,
+  fetchRoutingGroup,
   fetchRoutingGroups,
   fetchRoutingRules,
   fetchRuleActions,

--- a/src/store/modules/orderRouting/OrderRoutingState.ts
+++ b/src/store/modules/orderRouting/OrderRoutingState.ts
@@ -1,10 +1,10 @@
-import { RouteFilter } from "@/types";
+import { Group, RouteFilter } from "@/types";
 
 export default interface OrderRoutingState {
   groups: Array<any>; // runs
   routes: Array<any>;
   rules: Array<any>;
-  currentGroupId: string;
+  currentGroup: any;
   currentRouteId: string;
   currentRouteFilters: {
     [key: string]: {  // conditionTypeEnumId as key

--- a/src/store/modules/orderRouting/actions.ts
+++ b/src/store/modules/orderRouting/actions.ts
@@ -89,8 +89,6 @@ const actions: ActionTree<OrderRoutingState, RootState> = {
     try {
       const resp = await OrderRoutingService.fetchRoutingGroup(routingGroupId);
 
-      console.log(resp.data)
-
       if(!hasError(resp) && resp.data) {
         currentGroup = resp.data
       } else {

--- a/src/store/modules/orderRouting/actions.ts
+++ b/src/store/modules/orderRouting/actions.ts
@@ -77,7 +77,33 @@ const actions: ActionTree<OrderRoutingState, RootState> = {
     commit(types.ORDER_ROUTING_GROUPS_UPDATED, routingGroups)
   },
 
-  async setCurrentRoutingGroupId({ commit }, payload) {
+  async fetchCurrentRoutingGroup({ dispatch, state }, routingGroupId) {
+    const current = state.currentGroup
+    if(current.routingGroupId) {
+      dispatch("setCurrentRoutingGroup", current)
+      return;
+    }
+
+    let currentGroup = {}
+
+    try {
+      const resp = await OrderRoutingService.fetchRoutingGroup(routingGroupId);
+
+      console.log(resp.data)
+
+      if(!hasError(resp) && resp.data) {
+        currentGroup = resp.data
+      } else {
+        throw resp.data
+      }
+    } catch(err) {
+      logger.error(err);
+    }
+
+    dispatch("setCurrentRoutingGroup", currentGroup)
+  },
+
+  async setCurrentRoutingGroup({ commit }, payload) {
     commit(types.ORDER_ROUTING_CURRENT_GROUP_UPDATED, payload)
   },
 

--- a/src/store/modules/orderRouting/getters.ts
+++ b/src/store/modules/orderRouting/getters.ts
@@ -14,8 +14,7 @@ const getters: GetterTree<OrderRoutingState, RootState> = {
     return state.rules
   },
   getCurrentRoutingGroup(state) {
-    const currentRoutingGroup = state.groups?.find((group: Group) => group.routingGroupId === state.currentGroupId)
-    return currentRoutingGroup ? currentRoutingGroup : {}
+    return JSON.parse(JSON.stringify(state.currentGroup))
   },
   getCurrentOrderRouting(state) {
     const orderRouting = state.routes?.find((route: Route) => route.orderRoutingId === state.currentRouteId)

--- a/src/store/modules/orderRouting/index.ts
+++ b/src/store/modules/orderRouting/index.ts
@@ -4,6 +4,7 @@ import mutations from "./mutations"
 import { Module } from "vuex"
 import OrderRoutingState from "./OrderRoutingState"
 import RootState from "@/store/RootState"
+import { Route } from "@/types"
 
 const orderRoutingModule: Module<OrderRoutingState, RootState> = {
   namespaced: true,
@@ -11,7 +12,7 @@ const orderRoutingModule: Module<OrderRoutingState, RootState> = {
     groups: [],
     routes: [],
     rules: [],
-    currentGroupId: '', // choosing only to save id and not whole object, as when updating the state we don't need to care updating the state on two different places
+    currentGroup: {},
     currentRouteId: '',
     currentRouteFilters: {},
     ruleConditions: {},

--- a/src/store/modules/orderRouting/mutations.ts
+++ b/src/store/modules/orderRouting/mutations.ts
@@ -12,8 +12,8 @@ const mutations: MutationTree<OrderRoutingState> = {
   [types.ORDER_ROUTING_RULES_UPDATED](state, payload) {
     state.rules = payload
   },
-  [types.ORDER_ROUTING_CURRENT_GROUP_UPDATED](state, groupId) {
-    state.currentGroupId = groupId
+  [types.ORDER_ROUTING_CURRENT_GROUP_UPDATED](state, payload) {
+    state.currentGroup = payload
   },
   [types.ORDER_ROUTING_CURRENT_ROUTE_UPDATED](state, routeId) {
     state.currentRouteId = routeId

--- a/src/views/BrokeringRoute.vue
+++ b/src/views/BrokeringRoute.vue
@@ -105,7 +105,7 @@ import { IonBackButton, IonBadge, IonButtons, IonButton, IonCard, IonCardHeader,
 import { addCircleOutline, archiveOutline, reorderTwoOutline, saveOutline, timeOutline, timerOutline } from "ionicons/icons"
 import { useRouter } from "vue-router";
 import { useStore } from "vuex";
-import { computed, defineProps, ref } from "vue";
+import { computed, defineProps, onMounted, ref } from "vue";
 import { Group, Route } from "@/types";
 import ArchivedRoutingModal from "@/components/ArchivedRoutingModal.vue"
 import emitter from "@/event-bus";
@@ -130,14 +130,9 @@ const currentRoutingGroup = computed((): Group => store.getters["orderRouting/ge
 const orderRoutings = computed(() => store.getters["orderRouting/getOrderRoutings"])
 
 onIonViewWillEnter(async () => {
-  await store.dispatch("orderRouting/fetchOrderRoutings", props.routingGroupId)
+  await Promise.all([store.dispatch("orderRouting/fetchOrderRoutings", props.routingGroupId), store.dispatch("orderRouting/fetchCurrentRoutingGroup", props.routingGroupId)])
 
   initializeOrderRoutings();
-
-  // On refresh, the groups list is removed thus resulting is not fetching the current group information
-  if(!currentRoutingGroup.value.routingGroupId) {
-    await store.dispatch("orderRouting/fetchOrderRoutingGroups")
-  }
 
   description.value = currentRoutingGroup.value.description ? currentRoutingGroup.value.description : "No description available"
   emitter.on("initializeOrderRoutings", initializeOrderRoutings)

--- a/src/views/BrokeringRuns.vue
+++ b/src/views/BrokeringRuns.vue
@@ -16,7 +16,7 @@
     <ion-content>
       <main v-if="groups.length">
         <section>
-          <ion-card v-for="group in groups" :key="group.routingGroupId" @click="redirect(group.routingGroupId)">
+          <ion-card v-for="group in groups" :key="group.routingGroupId" @click="redirect(group)">
             <ion-card-header>
               <ion-card-title>
                 {{ group.groupName }}
@@ -46,6 +46,7 @@
 </template>
 
 <script setup lang="ts">
+import { Group } from "@/types";
 import { IonButton, IonButtons, IonCard, IonCardHeader, IonCardTitle, IonContent, IonHeader, IonIcon, IonItem, IonLabel, IonPage, IonTitle, IonToolbar, alertController, onIonViewWillEnter } from "@ionic/vue";
 import { addOutline } from "ionicons/icons"
 import { computed } from "vue";
@@ -85,9 +86,9 @@ async function addNewRun() {
   return newRunAlert.present();
 }
 
-async function redirect(routingGroupId: string) {
-  await store.dispatch('orderRouting/setCurrentRoutingGroupId', routingGroupId)
-  router.push(`brokering/${routingGroupId}/routes`)
+async function redirect(group: Group) {
+  await store.dispatch('orderRouting/setCurrentRoutingGroup', group)
+  router.push(`brokering/${group.routingGroupId}/routes`)
 }
 
 </script>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Added support to fetch the currentRoutingRun information is not already present on page refresh

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/order-routing-rules#contribution-guideline)