### PR TITLE
Improved: support to have a default value for measurement system when selecting proximity and removed equals operator support from safety stock filter(#86)

### DIFF
--- a/src/components/AddInventoryFilterOptionsModal.vue
+++ b/src/components/AddInventoryFilterOptionsModal.vue
@@ -60,7 +60,7 @@ let inventoryRuleConditions = ref({}) as any
 let enumerations = ref([]) as any
 const hiddenOptions = ["IIP_MSMNT_SYSTEM"]
 // managing this object, as we have some filters for which we need to have its associated filter, like in this case when we have PROXIMITY we also need to add MEASUREMENT_SYSTEM(this is not available on UI for selection and included in hiddenOptions)
-const associatedOptions = { IIP_PROXIMITY: 'IIP_MSMNT_SYSTEM' } as any
+const associatedOptions = { IIP_PROXIMITY: { enum: "IIP_MSMNT_SYSTEM", defaultValue: "IMPERIAL" }} as any
 
 onMounted(() => {
   inventoryRuleConditions.value = props.ruleConditions ? JSON.parse(JSON.stringify(props.ruleConditions)) : {}
@@ -69,8 +69,7 @@ onMounted(() => {
 
 function addConditionOption(condition: any) {
   const isConditionOptionAlreadyApplied = isConditionOptionSelected(condition.enumCode)?.fieldName
-  const associatedEnum = enums.value[props.parentEnumId][associatedOptions[condition.enumId]]
-
+  const associatedEnum = enums.value[props.parentEnumId][associatedOptions[condition.enumId]?.enum]
   if(isConditionOptionAlreadyApplied) {
     delete inventoryRuleConditions.value[condition.enumCode]
     // When removing a condition, also remove its associated option if available
@@ -96,6 +95,7 @@ function addConditionOption(condition: any) {
         routingRuleId: props.routingRuleId,
         conditionTypeEnumId: props.conditionTypeEnumId,
         fieldName: associatedEnum.enumCode,
+        fieldValue: associatedOptions[condition.enumId]?.defaultValue,
         sequenceNum: Object.keys(inventoryRuleConditions.value).length && inventoryRuleConditions.value[Object.keys(inventoryRuleConditions.value)[Object.keys(inventoryRuleConditions.value).length - 1]]?.sequenceNum >= 0 ? inventoryRuleConditions.value[Object.keys(inventoryRuleConditions.value)[Object.keys(inventoryRuleConditions.value).length - 1]].sequenceNum + 5 : 0,  // added check for `>= 0` as sequenceNum can be 0 which will result in again setting the new seqNum to 0
         createdDate: DateTime.now().toMillis()
       })

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -35,7 +35,6 @@
   "duration": "duration",
   "Edit": "Edit",
   "Error getting user profile": "Error getting user profile",
-  "equals": "equals",
   "Failed to create brokering run": "Failed to create brokering run",
   "Failed to create inventory rule": "Failed to create inventory rule",
   "Failed to create order routing": "Failed to create order routing",

--- a/src/views/BrokeringQuery.vue
+++ b/src/views/BrokeringQuery.vue
@@ -136,7 +136,6 @@
                 <ion-label>{{ translate("Brokering safety stock") }}</ion-label>
                 <ion-chip outline>
                   <ion-select :placeholder="translate('operator')" aria-label="operator" interface="popover" :value="getFilterValue(inventoryRuleFilterOptions, conditionFilterEnums, 'BRK_SAFETY_STOCK').operator" @ionChange="updateOperator($event)">
-                    <ion-select-option value="equals">{{ translate("equals") }}</ion-select-option>
                     <ion-select-option value="greater-equals">{{ translate("greater than or equal to") }}</ion-select-option>
                     <ion-select-option value="greater">{{ translate("greater") }}</ion-select-option>
                   </ion-select>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #86 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Removed `equals` operator from safety stock filter, as there is no use case when we will create a rule with a check for safety stock with exact value, in most likely all the cases we will check for either safety stock greater or greaterThanEqualTo a specific value
- When selecting proximity filter, we are making a defaultValue for measurementSystem to miles

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/order-routing-rules#contribution-guideline)