### PR TITLE
Improved: button label when the description for the group is missing and handled case to not update the description when initially not available and after update was left empty(#101)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2,6 +2,7 @@
   "A store repesents a company or a unique catalog of products. If your OMS is connected to multiple eCommerce stores sellling different collections of products, you may have multiple Product Stores set up in HotWax Commerce.": "A store repesents a company or a unique catalog of products. If your OMS is connected to multiple eCommerce stores sellling different collections of products, you may have multiple Product Stores set up in HotWax Commerce.",
   "Actions": "Actions",
   "Active": "Active",
+  "Add": "Add",
   "Add inventory rule": "Add inventory rule",
   "Allocated Items": "Allocated Items",
   "Allow partial allocation": "Allow partial allocation",

--- a/src/views/BrokeringRoute.vue
+++ b/src/views/BrokeringRoute.vue
@@ -63,7 +63,7 @@
             <ion-item lines="none">
               <h2>{{ translate("Description") }}</h2>
               <ion-button fill="clear" slot="end" @click="isDescUpdating ? updateGroupDescription() : (isDescUpdating = !isDescUpdating)">
-                {{ translate(isDescUpdating ? "Save" : "Edit") }}
+                {{ translate(isDescUpdating ? "Save" : description ? "Edit" : "Add") }}
               </ion-button>
             </ion-item>
             <ion-item :color="isDescUpdating ? 'light' : ''" lines="none">

--- a/src/views/BrokeringRoute.vue
+++ b/src/views/BrokeringRoute.vue
@@ -444,8 +444,9 @@ function getArchivedOrderRoutings() {
 }
 
 async function updateGroupDescription() {
-  // Do not update description, if the desc is unchanged, and we do not have routingGroupId, and description is left empty
-  if(props.routingGroupId && currentRoutingGroup.value.description !== description.value) {
+  // Do not update description, if the desc is unchanged, and we do not have routingGroupId
+  // Added conversion using `!!`, as if the group does not have a description then we get `undefined` and if the description entered by the user is left empty then `undefined != ''` is true and thus it makes an api call, even when description is unchanged in this case.
+  if(props.routingGroupId && (!!currentRoutingGroup.value.description != !!description.value)) {
     const routingGroupId = await updateRoutingGroup({ routingGroupId: props.routingGroupId, productStoreId: currentRoutingGroup.value.productStoreId, description: description.value })
     if(routingGroupId) {
       await store.dispatch("orderRouting/setCurrentGroup", { ...currentRoutingGroup.value, description: description.value })

--- a/src/views/BrokeringRuns.vue
+++ b/src/views/BrokeringRuns.vue
@@ -20,13 +20,13 @@
         </section>
 
         <aside class="filters">
-          <ion-list-header>{{ "Product Stores" }}</ion-list-header>
           <ion-list>
-            <ion-item lines="none">
-              <ion-radio-group :value="currentEComStore.productStoreId" @ionChange="setEComStore($event)">
-                <ion-radio v-for="store in (userProfile ? userProfile.stores : [])" :key="store.productStoreId" :value="store.productStoreId">{{ store.storeName }}</ion-radio>
-              </ion-radio-group>
-            </ion-item>
+            <ion-list-header>{{ translate("Product Store") }}</ion-list-header>
+            <ion-radio-group :value="currentEComStore.productStoreId" @ionChange="setEComStore($event)">
+              <ion-item v-for="store in (userProfile ? userProfile.stores : [])" :key="store.productStoreId" lines="none">
+                <ion-radio :value="store.productStoreId">{{ store.storeName }}</ion-radio>
+              </ion-item>
+            </ion-radio-group>
           </ion-list>
         </aside>
 

--- a/src/views/BrokeringRuns.vue
+++ b/src/views/BrokeringRuns.vue
@@ -44,7 +44,7 @@
                   {{ group.groupName }}
                 </ion-card-title>
               </ion-card-header>
-              <ion-item>
+              <ion-item v-if="group.description">
                 {{ group.description }}
               </ion-item>
               <ion-item>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #101

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->

After:

![image](https://github.com/hotwax/order-routing-rules/assets/41404838/c38e3a7d-ffff-4fcd-a196-782efcdace16)


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/order-routing-rules#contribution-guideline)