### PR TITLE
Implemented: support to display the runTime and frequency for a group on the list page

### DIFF
--- a/src/views/BrokeringRoute.vue
+++ b/src/views/BrokeringRoute.vue
@@ -85,12 +85,10 @@
           </main>
           <aside>
             <ion-card>
-              <ion-card-header>
-                <ion-card-title>
-                  {{ translate("Scheduler") }}
-                </ion-card-title>
-                <ion-badge>{{ timeTillJobUsingSeconds(job.nextExecutionDateTime) }}</ion-badge>
-              </ion-card-header>
+              <ion-item lines="none">
+                <h2>{{ translate("Scheduler") }}</h2>
+                <ion-badge slot="end">{{ timeTillJobUsingSeconds(job.nextExecutionDateTime) }}</ion-badge>
+              </ion-item>
               <ion-item v-show="typeof isOmsConnectionExist === 'boolean' && !isOmsConnectionExist" lines="none">
                 <ion-label color="danger" class="ion-text-wrap">
                   {{ translate("Connection configuration is missing for oms.") }}
@@ -139,7 +137,7 @@
 </template>
 
 <script setup lang="ts">
-import { IonBackButton, IonBadge, IonButtons, IonButton, IonCard, IonCardHeader, IonCardTitle, IonChip, IonContent, IonFab, IonFabButton, IonHeader, IonIcon, IonItem, IonLabel, IonList, IonListHeader, IonPage, IonReorder, IonReorderGroup, IonSelect, IonSelectOption, IonTextarea, IonTitle, IonToolbar, alertController, modalController, onIonViewWillEnter } from "@ionic/vue";
+import { IonBackButton, IonBadge, IonButtons, IonButton, IonCard, IonChip, IonContent, IonFab, IonFabButton, IonHeader, IonIcon, IonItem, IonLabel, IonList, IonListHeader, IonPage, IonReorder, IonReorderGroup, IonSelect, IonSelectOption, IonTextarea, IonTitle, IonToolbar, alertController, modalController, onIonViewWillEnter } from "@ionic/vue";
 import { addCircleOutline, archiveOutline, refreshOutline, reorderTwoOutline, saveOutline, timeOutline, timerOutline } from "ionicons/icons"
 import { onBeforeRouteLeave, useRouter } from "vue-router";
 import { useStore } from "vuex";

--- a/src/views/BrokeringRuns.vue
+++ b/src/views/BrokeringRuns.vue
@@ -48,8 +48,8 @@
                 {{ group.description }}
               </ion-item>
               <ion-item>
-                <ion-label>{{ group.frequency ? group.frequency : "-" }}</ion-label>
-                <ion-label slot="end">{{ group.runTime ? group.runTime : "-" }}</ion-label>
+                <ion-label>{{ group.schedule ? getScheduleFrequency(group.schedule.cronExpression) : "-" }}</ion-label>
+                <ion-label slot="end">{{ group.schedule ? getTimeFromSeconds(group.schedule.nextExecutionDateTime) : "-" }}</ion-label>
               </ion-item>
               <ion-item>
                 {{ getDateAndTime(group.createdDate) }}
@@ -72,7 +72,7 @@
 import emitter from "@/event-bus";
 import { translate } from "@/i18n";
 import { Group } from "@/types";
-import { getDateAndTime, showToast } from "@/utils";
+import { getDateAndTime, getTimeFromSeconds, showToast } from "@/utils";
 import { IonButton, IonButtons, IonCard, IonCardHeader, IonCardTitle, IonContent, IonHeader, IonIcon, IonItem, IonLabel, IonList, IonListHeader, IonPage, IonRadioGroup, IonRadio, IonSearchbar, IonSpinner, IonTitle, IonToolbar, alertController, onIonViewWillEnter } from "@ionic/vue";
 import { addOutline } from "ionicons/icons"
 import { computed, ref } from "vue";
@@ -84,6 +84,8 @@ const router = useRouter()
 const groups = computed(() => store.getters["orderRouting/getRoutingGroups"])
 const userProfile = computed(() => store.getters["user/getUserProfile"])
 const currentEComStore = computed(() => store.getters["user/getCurrentEComStore"])
+
+const cronExpressions = JSON.parse(process.env?.VUE_APP_CRON_EXPRESSIONS)
 
 let isLoading = ref(false)
 let queryString = ref("")
@@ -148,6 +150,10 @@ async function setEComStore(event: CustomEvent) {
     brokeringGroups.value = JSON.parse(JSON.stringify(groups.value))
   }
   emitter.emit("dismissLoader")
+}
+
+function getScheduleFrequency(cronExp: string) {
+  return Object.entries(cronExpressions).find(([description, expression]) => expression === cronExp)?.[0] || "-"
 }
 
 async function redirect(group: Group) {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Added support to display the runTime and frequency for a group

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
After:

![image](https://github.com/hotwax/order-routing-rules/assets/41404838/d824ad82-8dce-4be7-93ab-8cb0ccd993d3)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/order-routing-rules#contribution-guideline)