### PR TITLE
Improved: save button action to not show an alert before save on routing list page(#119)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -63,7 +63,6 @@
   "Login": "Login",
   "Logout": "Logout",
   "Low": "Low",
-  "Make sure that you've reviewed the routes order and status before saving.": "Make sure that you've reviewed the routes order and status before saving.",
   "Make sure that you've reviewed the selected filters and conditions before saving.": "Make sure that you've reviewed the selected filters and conditions before saving.",
   "Medium": "Medium",
   "Move items to": "Move items to",

--- a/src/views/BrokeringRoute.vue
+++ b/src/views/BrokeringRoute.vue
@@ -132,7 +132,7 @@
         </section>
       </div>
       <ion-fab vertical="bottom" horizontal="end" slot="fixed">
-        <ion-fab-button :disabled="!hasUnsavedChanges" @click="save">
+        <ion-fab-button :disabled="!hasUnsavedChanges" @click="saveRoutingGroup">
           <ion-icon :icon="saveOutline" />
         </ion-fab-button>
       </ion-fab>
@@ -493,28 +493,6 @@ async function updateOrderRouting(routing: Route, fieldToUpdate: string, value: 
   })
   hasUnsavedChanges.value = true
   initializeOrderRoutings()
-}
-
-async function save() {
-  const confirmAlert = await alertController
-    .create({
-      header: translate("Confirm"),
-      message: translate("Make sure that you've reviewed the routes order and status before saving."),
-      buttons: [
-        {
-          text: translate("Cancel"),
-          role: "cancel",
-        },
-        {
-          text: translate("Save"),
-          handler: async () => {
-            await saveRoutingGroup()
-          }
-        }
-      ]
-    });
-
-  return confirmAlert.present();
 }
 
 async function saveRoutingGroup() {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #119

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Remove the method to show the alert on clicking save button on routing list page and save the changes directly.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/order-routing-rules#contribution-guideline)