### PR TITLE
Improved: UI to display the rule status in the menu list(#117)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -51,7 +51,6 @@
   "greater than or equal to": "greater than or equal to",
   "High": "High",
   "History": "History",
-  "Inactive": "Inactive",
   "Inventory Filters": "Inventory Filters",
   "Inventory rule created successfully": "Inventory rule created successfully",
   "Inventory Sort": "Inventory Sort",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -51,6 +51,7 @@
   "greater than or equal to": "greater than or equal to",
   "High": "High",
   "History": "History",
+  "Inactive": "Inactive",
   "Inventory Filters": "Inventory Filters",
   "Inventory rule created successfully": "Inventory rule created successfully",
   "Inventory Sort": "Inventory Sort",

--- a/src/views/BrokeringQuery.vue
+++ b/src/views/BrokeringQuery.vue
@@ -88,7 +88,7 @@
               <ion-item lines="full" v-for="rule in inventoryRules" :key="rule.routingRuleId && inventoryRules.length" :color="rule.routingRuleId === selectedRoutingRule?.routingRuleId ? 'light' : ''" @click="fetchRuleInformation(rule.routingRuleId)" button>
                 <ion-label>
                   <h2>{{ rule.ruleName }}</h2>
-                  <ion-note :color="rule.statusId === 'RULE_ACTIVE' ? 'success' : ''">{{ rule.statusId === "RULE_ACTIVE" ? translate("Active") : translate("Inactive") }}</ion-note>
+                  <ion-note :color="rule.statusId === 'RULE_ACTIVE' ? 'success' : rule.statusId === 'RULE_ARCHIVED' ? 'warning' : ''">{{ rule.statusId === "RULE_ACTIVE" ? translate("Active") : rule.statusId === "RULE_ARCHIVED" ? translate("Archived") : translate("Draft") }}</ion-note>
                 </ion-label>
                 <!-- Don't display reordering option when there is a single rule -->
                 <ion-reorder v-show="inventoryRules.length > 1" />

--- a/src/views/BrokeringQuery.vue
+++ b/src/views/BrokeringQuery.vue
@@ -86,7 +86,10 @@
           <ion-list>
             <ion-reorder-group @ionItemReorder="doReorder($event)" :disabled="false">
               <ion-item lines="full" v-for="rule in inventoryRules" :key="rule.routingRuleId && inventoryRules.length" :color="rule.routingRuleId === selectedRoutingRule?.routingRuleId ? 'light' : ''" @click="fetchRuleInformation(rule.routingRuleId)" button>
-                <ion-label>{{ rule.ruleName }}</ion-label>
+                <ion-label>
+                  <h2>{{ rule.ruleName }}</h2>
+                  <ion-note :color="rule.statusId === 'RULE_ACTIVE' ? 'success' : ''">{{ rule.statusId === "RULE_ACTIVE" ? translate("Active") : translate("Inactive") }}</ion-note>
+                </ion-label>
                 <!-- Don't display reordering option when there is a single rule -->
                 <ion-reorder v-show="inventoryRules.length > 1" />
               </ion-item>
@@ -245,7 +248,7 @@
 </template>
 
 <script setup lang="ts">
-import { IonButton, IonCard, IonCardContent, IonCardHeader, IonCardTitle, IonChip, IonContent, IonIcon, IonInput, IonItem, IonItemDivider, IonItemGroup, IonLabel, IonList, IonPage, IonReorder, IonReorderGroup, IonSelect, IonSelectOption, IonToggle, alertController, modalController, onIonViewWillEnter, popoverController } from "@ionic/vue";
+import { IonButton, IonCard, IonCardContent, IonCardHeader, IonCardTitle, IonChip, IonContent, IonIcon, IonInput, IonItem, IonItemDivider, IonItemGroup, IonLabel, IonList, IonNote, IonPage, IonReorder, IonReorderGroup, IonSelect, IonSelectOption, IonToggle, alertController, modalController, onIonViewWillEnter, popoverController } from "@ionic/vue";
 import { addCircleOutline, bookmarkOutline, chevronUpOutline, filterOutline, golfOutline, optionsOutline, playForwardOutline, pulseOutline, swapVerticalOutline, timeOutline } from "ionicons/icons"
 import { onBeforeRouteLeave, useRouter } from "vue-router";
 import { computed, defineProps, ref } from "vue";


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #117 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Display `Active` with success color when rule status is `RULE_ACTIVE`
- Display `Archived` with warning color when status is `RULE_ARCHIVED`
- Display `Draft` with default color when status is `RULE_DRAFT`

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

After:

![image](https://github.com/hotwax/order-routing-rules/assets/41404838/ad388670-fec7-4902-9350-b1470effc8db)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/order-routing-rules#contribution-guideline)