### PR TITLE
Fixed: run not displayed after creation immediately(#135)

### DIFF
--- a/src/store/modules/orderRouting/actions.ts
+++ b/src/store/modules/orderRouting/actions.ts
@@ -60,7 +60,7 @@ const actions: ActionTree<OrderRoutingState, RootState> = {
   async createRoutingGroup({ dispatch }, groupName) {
     const payload = {
       groupName,
-      productStoreId: "STORE",
+      productStoreId: store.state.user.currentEComStore.productStoreId,
       createdDate: DateTime.now().toMillis()
     }
     try {
@@ -68,7 +68,7 @@ const actions: ActionTree<OrderRoutingState, RootState> = {
 
       if(!hasError(resp)) {
         showToast(translate("Brokering run created"))
-        dispatch("fetchOrderRoutingGroups")
+        await dispatch("fetchOrderRoutingGroups")
       } else {
         throw resp.data
       }

--- a/src/views/BrokeringRuns.vue
+++ b/src/views/BrokeringRuns.vue
@@ -142,14 +142,15 @@ async function addNewRun() {
     }]
   })
 
-  newRunAlert.onDidDismiss().then((result: any) => {
+  newRunAlert.onDidDismiss().then(async (result: any) => {
     // considering that if we have role, then its negative action and thus not need to create run
     if(result.role) {
       return;
     }
 
     if(result.data?.values?.runName.trim()) {
-      store.dispatch("orderRouting/createRoutingGroup", result.data.values.runName.trim())
+      await store.dispatch("orderRouting/createRoutingGroup", result.data.values.runName.trim())
+      brokeringGroups.value = JSON.parse(JSON.stringify(groups.value))
     }
   })
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related Issue #135 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Added check to wait until the updated information is being fetched and make the productStoreId dynamic when creating a new run.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/order-routing-rules#contribution-guideline)