### PR TITLE
Fixed: case to display productStoreId in case the storeName is not available(#149)

### DIFF
--- a/src/views/BrokeringRuns.vue
+++ b/src/views/BrokeringRuns.vue
@@ -24,7 +24,7 @@
             <ion-list-header>{{ translate("Product Store") }}</ion-list-header>
             <ion-radio-group :value="currentEComStore.productStoreId" @ionChange="setEComStore($event)">
               <ion-item v-for="store in (userProfile ? userProfile.stores : [])" :key="store.productStoreId" lines="none">
-                <ion-radio :value="store.productStoreId">{{ store.storeName }}</ion-radio>
+                <ion-radio :value="store.productStoreId">{{ store.storeName || store.productStoreId }}</ion-radio>
               </ion-item>
             </ion-radio-group>
           </ion-list>

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -62,7 +62,7 @@
           </ion-card-content>
           <ion-item lines="none">
             <ion-select :label="translate('Select store')" interface="popover" :value="currentEComStore.productStoreId" @ionChange="setEComStore($event)">
-              <ion-select-option v-for="store in (userProfile ? userProfile.stores : [])" :key="store.productStoreId" :value="store.productStoreId" >{{ store.storeName }}</ion-select-option>
+              <ion-select-option v-for="store in (userProfile ? userProfile.stores : [])" :key="store.productStoreId" :value="store.productStoreId" >{{ store.storeName || store.productStoreId }}</ion-select-option>
             </ion-select>
           </ion-item>
         </ion-card>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related Issue #149 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Added check to display storeName if available otherwise display productStoreId

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
Before:

![image](https://github.com/hotwax/order-routing-rules/assets/41404838/401db054-d60f-47d3-9508-c00d9dcae59c)

After:

![image](https://github.com/hotwax/order-routing-rules/assets/41404838/68aedff8-62ba-491a-af19-ef1ba0fd5982)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/order-routing-rules#contribution-guideline)