### PR TITLE
Fixed: support to not open the details page for unarchived route(#145)

### DIFF
--- a/src/components/GroupHistoryModal.vue
+++ b/src/components/GroupHistoryModal.vue
@@ -17,7 +17,7 @@
           <h3>{{ getTime(history.startTime) }}</h3>
           <p>{{ getDate(history.startTime) }}</p>
         </ion-label>
-        <ion-badge color="dark">{{ timeTillRun(history.endTime) }}</ion-badge>
+        <ion-badge color="dark" v-if="history.endTime">{{ timeTillRun(history.endTime) }}</ion-badge>
       </ion-item>
     </ion-list>
   </ion-content>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -116,6 +116,7 @@
   "Sales Channel": "Sales Channel",
   "Save": "Save",
   "Save changes": "Save changes",
+  "Save changes before moving to the details page of unarchived route": "Save changes before moving to the details page of unarchived route",
   "Schedule": "Schedule",
   "Scheduler": "Scheduler",
   "Search groups": "Search groups",

--- a/src/views/BrokeringRoute.vue
+++ b/src/views/BrokeringRoute.vue
@@ -81,7 +81,7 @@
                 <h3>{{ getTime(groupHistory[0].startTime) }}</h3>
                 <p>{{ getDate(groupHistory[0].startTime) }}</p>
               </ion-label>
-              <ion-badge color="dark">{{ timeTillRun(groupHistory[0].endTime) }}</ion-badge>
+              <ion-badge color="dark" v-if="groupHistory[0].endTime">{{ timeTillRun(groupHistory[0].endTime) }}</ion-badge>
             </ion-item>
           </main>
           <aside>

--- a/src/views/BrokeringRoute.vue
+++ b/src/views/BrokeringRoute.vue
@@ -372,6 +372,13 @@ async function runNow() {
 }
 
 async function redirect(orderRouting: Route) {
+  let isRoutingArchived = currentRoutingGroup.value["routings"].some((routing: any) => routing.orderRoutingId === orderRouting.orderRoutingId && routing.statusId === "ROUTING_ARCHIVED" )
+
+  if(isRoutingArchived) {
+    showToast(translate("Save changes before moving to the details page of unarchived route"))
+    return;
+  }
+
   await store.dispatch("orderRouting/setCurrentOrderRouting", orderRouting)
   router.push(`${orderRouting.orderRoutingId}/rules`)
 }


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related Issue #145 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- When finding the index number for routes we honor the active and draft routes, but as the route is unarchived but not saved in the state, then the index for the route is not found resulting in displaying NaN.
- Added toast message to not redirect the user to the details page in the above case
- Fixed a case when timeTillJob is not found

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/order-routing-rules#contribution-guideline)