### PR TITLE
Improved: logic to run the job successfully on clicking runNow(#147)

### DIFF
--- a/src/views/BrokeringRoute.vue
+++ b/src/views/BrokeringRoute.vue
@@ -114,9 +114,9 @@
               </ion-item>
               <ion-item lines="none">
                 <ion-icon slot="start" :icon="timerOutline"/>
-                <!-- When the group is in draft status, do not display the frequency and juust display the label for schedule -->
-                <ion-label v-if="job.paused === 'Y'">{{ translate("Schedule") }}</ion-label>
-                <ion-label v-if="job.paused === 'Y'" slot="end">{{ "-" }}</ion-label>
+                <!-- When the group is in draft status or the job is not present, do not display the frequency and just display the label for schedule -->
+                <ion-label v-if="!job.paused || job.paused === 'Y'">{{ translate("Schedule") }}</ion-label>
+                <ion-label v-if="!job.paused || job.paused === 'Y'" slot="end">{{ "-" }}</ion-label>
                 <ion-select v-else :label="translate('Schedule')" interface="popover" :placeholder="translate('Select')" :value="job.cronExpression" @ionChange="updateCronExpression($event)">
                   <ion-select-option v-for="(expression, description) in cronExpressions" :key="expression" :value="expression">{{ description }}</ion-select-option>
                 </ion-select>

--- a/src/views/BrokeringRoute.vue
+++ b/src/views/BrokeringRoute.vue
@@ -357,7 +357,7 @@ async function runNow() {
             if(!job.value.jobName) {
               const payload = {
                 routingGroupId: props.routingGroupId,
-                paused: "Y",
+                paused: "Y",  // passing Y as we just need to configure the scheduler and do not need to schedule it in active state
               }
 
               try {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
Related Issue #147 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
This change will allow user to run the service directly without scheduling it in active state

Clicking runNow when the group does not have a scheduler configured(job is not already scheduled) results in an error. Improved support to check whether the scheduler is configured for the group or not, if not then before calling runNow service, scheduling the job as draft to configure the scheduler and then making the runNow request.

Added check to not allow user to select the schedule if the job is not present or job status is draft.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/order-routing-rules#contribution-guideline)