### PR TITLE
Improved: UI for the routing history to display message when no history is present and added lines full to have separation between the history modal title and its details(#166)

### DIFF
--- a/src/components/RoutingHistoryModal.vue
+++ b/src/components/RoutingHistoryModal.vue
@@ -12,7 +12,7 @@
   
   <ion-content>
     <ion-list>
-      <ion-item>
+      <ion-item lines="full">
         <ion-label>
           <h1>{{ routingName }}</h1>
           <p>{{ groupName }}</p>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -79,6 +79,7 @@
   "No available history for this group": "No available history for this group",
   "No available history for this route": "No available history for this route",
   "No archived routings": "No archived routings",
+  "No run history": "No run history",
   "No runs scheduled": "No runs scheduled",
   "No time zone found": "No time zone found",
   "OMS": "OMS",

--- a/src/views/BrokeringRoute.vue
+++ b/src/views/BrokeringRoute.vue
@@ -36,7 +36,7 @@
                   <ion-icon :icon="timeOutline" slot="start" />
                   <ion-label>{{ translate("Last run") }}</ion-label>
                   <ion-chip outline @click.stop="openRoutingHistoryModal(routing.orderRoutingId, routing.routingName)">
-                    <ion-label>{{ routingHistory[routing.orderRoutingId] ? getDateAndTimeShort(routingHistory[routing.orderRoutingId][0].startDate) : "-" }}</ion-label>
+                    <ion-label>{{ routingHistory[routing.orderRoutingId] ? getDateAndTimeShort(routingHistory[routing.orderRoutingId][0].startDate) : translate("No run history") }}</ion-label>
                   </ion-chip>
                 </ion-item>
                 <ion-item lines="none">


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related Issue #166

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
After:
Displayed `No run history`

![image](https://github.com/hotwax/order-routing-rules/assets/41404838/5eccb158-c25f-4756-9f01-0cb7ec5ca417)

Added lines 'full`

![image](https://github.com/hotwax/order-routing-rules/assets/41404838/9d34be2c-19d7-4e54-b496-3bd0daf4a8b4)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/order-routing-rules#contribution-guideline)