### PR TITLE
Improved: check to display productStore options only if having multiple options to select from and removed the search option from the page(#156)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -118,7 +118,6 @@
   "Save changes before moving to the details page of unarchived route": "Save changes before moving to the details page of unarchived route",
   "Schedule": "Schedule",
   "Scheduler": "Scheduler",
-  "Search groups": "Search groups",
   "Search time zones": "Search time zones",
   "Select": "Select",
   "Select filter to apply": "Select filter to apply",

--- a/src/theme/variables.css
+++ b/src/theme/variables.css
@@ -305,14 +305,6 @@ http://ionicframework.com/docs/theming/ */
     margin: var(--spacer-lg);
   }
 
-  .filters {
-    margin-top: var(--spacer-lg);
-  }
-
-  .filters {
-    margin-top: var(--spacer-lg);
-  }
-
   .find > .filters{
     display: unset;
   }

--- a/src/views/BrokeringRuns.vue
+++ b/src/views/BrokeringRuns.vue
@@ -15,10 +15,6 @@
 
     <ion-content>
       <div class="find">
-        <section class="search">
-          <ion-searchbar :placeholder="translate('Search groups')" v-model="queryString" @keyup.enter="filterGroups()" />
-        </section>
-
         <aside class="filters">
           <ion-list>
             <ion-list-header>{{ translate("Product Store") }}</ion-list-header>
@@ -83,7 +79,7 @@ import emitter from "@/event-bus";
 import { translate } from "@/i18n";
 import { Group } from "@/types";
 import { getDateAndTime, showToast } from "@/utils";
-import { IonBadge, IonButton, IonButtons, IonCard, IonContent, IonHeader, IonIcon, IonItem, IonLabel, IonList, IonListHeader, IonPage, IonRadioGroup, IonRadio, IonSearchbar, IonSpinner, IonTitle, IonToolbar, alertController, onIonViewWillEnter } from "@ionic/vue";
+import { IonBadge, IonButton, IonButtons, IonCard, IonContent, IonHeader, IonIcon, IonItem, IonLabel, IonList, IonListHeader, IonPage, IonRadioGroup, IonRadio, IonSpinner, IonTitle, IonToolbar, alertController, onIonViewWillEnter } from "@ionic/vue";
 import { addOutline } from "ionicons/icons"
 import { DateTime } from "luxon";
 import { computed, ref } from "vue";
@@ -99,7 +95,6 @@ const currentEComStore = computed(() => store.getters["user/getCurrentEComStore"
 const cronExpressions = JSON.parse(process.env?.VUE_APP_CRON_EXPRESSIONS)
 
 let isLoading = ref(false)
-let queryString = ref("")
 let brokeringGroups = ref([]) as any
 
 onIonViewWillEnter(async () => {
@@ -113,12 +108,6 @@ onIonViewWillEnter(async () => {
 function timeTillRun(time: any) {
   const timeDiff = DateTime.fromMillis(time).diff(DateTime.local());
   return DateTime.local().plus(timeDiff).toRelative();
-}
-
-function filterGroups() {
-  // Before filtering the groups, reassinging it with state, if we have searched for a specific character and then updates the search string then we need to again filter on all the groups and not on the previously searched results
-  brokeringGroups.value = JSON.parse(JSON.stringify(groups.value))
-  brokeringGroups.value = brokeringGroups.value.filter((group: any) => group.groupName.toLowerCase().includes(queryString.value.toLowerCase()))
 }
 
 async function addNewRun() {

--- a/src/views/BrokeringRuns.vue
+++ b/src/views/BrokeringRuns.vue
@@ -14,8 +14,9 @@
     </ion-header>
 
     <ion-content>
-      <div class="find">
-        <aside class="filters">
+      <!-- Adding find class only when we are displaying product stores, as adding this class takes specific space on page -->
+      <div :class="userProfile?.stores?.length > 1 ? 'find' : ''">
+        <aside class="filters" v-if="userProfile?.stores?.length > 1">
           <ion-list>
             <ion-list-header>{{ translate("Product Store") }}</ion-list-header>
             <ion-radio-group :value="currentEComStore.productStoreId" @ionChange="setEComStore($event)">


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related Issue #156

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
After:

Removed search option:

![image](https://github.com/hotwax/order-routing-rules/assets/41404838/cb34a194-60b8-4f9e-bdc6-07f4119ecba6)


Removed product Store options when having a single productStore:

![image](https://github.com/hotwax/order-routing-rules/assets/41404838/f89456f9-7f58-427b-bdc1-1cd65ff23022)


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/order-routing-rules#contribution-guideline)