### PR TITLE
Improved: UI to move auto cancel days toggle inside unfillable items card(#158)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -4,7 +4,6 @@
   "Active": "Active",
   "Add": "Add",
   "Add inventory rule": "Add inventory rule",
-  "Allocated Items": "Allocated Items",
   "Allow partial allocation": "Allow partial allocation",
   "Already passed": "Already passed",
   "App": "App",

--- a/src/views/BrokeringQuery.vue
+++ b/src/views/BrokeringQuery.vue
@@ -184,16 +184,6 @@
               <ion-card>
                 <ion-card-header>
                   <ion-card-title>
-                    {{ translate("Allocated Items") }}
-                  </ion-card-title>
-                </ion-card-header>
-                <ion-item lines="none">
-                  <ion-toggle :checked="inventoryRuleActions[actionEnums['RM_AUTO_CANCEL_DATE'].id]?.actionValue" @ionChange="updateClearAutoCancelDays($event.detail.checked)">{{ translate("Clear auto cancel days") }}</ion-toggle>
-                </ion-item>
-              </ion-card>
-              <ion-card>
-                <ion-card-header>
-                  <ion-card-title>
                     {{ translate("Partially available") }}
                   </ion-card-title>
                 </ion-card-header>
@@ -232,6 +222,9 @@
                   <ion-select :placeholder="translate('queue')" :label="translate('Queue')" interface="popover" :value="inventoryRuleActions[ruleActionType]?.actionValue" @ionChange="updateRuleActionValue($event.detail.value)">
                     <ion-select-option v-for="(facility, facilityId) in facilities" :key="facilityId" :value="facilityId">{{ facility.facilityName || facilityId }}</ion-select-option>
                   </ion-select>
+                </ion-item>
+                <ion-item lines="none">
+                  <ion-toggle :checked="inventoryRuleActions[actionEnums['RM_AUTO_CANCEL_DATE'].id]?.actionValue" @ionChange="updateClearAutoCancelDays($event.detail.checked)">{{ translate("Clear auto cancel days") }}</ion-toggle>
                 </ion-item>
                 <ion-item lines="none">
                   <ion-label>{{ translate("Auto cancel days") }}</ion-label>

--- a/src/views/BrokeringQuery.vue
+++ b/src/views/BrokeringQuery.vue
@@ -226,7 +226,7 @@
                 <ion-item lines="none">
                   <ion-toggle :checked="inventoryRuleActions[actionEnums['RM_AUTO_CANCEL_DATE'].id]?.actionValue" @ionChange="updateClearAutoCancelDays($event.detail.checked)">{{ translate("Clear auto cancel days") }}</ion-toggle>
                 </ion-item>
-                <ion-item lines="none">
+                <ion-item lines="none" v-show="!inventoryRuleActions[actionEnums['RM_AUTO_CANCEL_DATE'].id]?.actionValue">
                   <ion-label>{{ translate("Auto cancel days") }}</ion-label>
                   <ion-chip outline @click="updateAutoCancelDays()">{{ inventoryRuleActions[actionEnums["AUTO_CANCEL_DAYS"].id]?.actionValue ? `${inventoryRuleActions[actionEnums["AUTO_CANCEL_DAYS"].id].actionValue} days` : translate("select days") }}</ion-chip>
                 </ion-item>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related Issue #158 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Moved auto cancel days toggle inside the unfillable items card
- Added support to allow users to only add `autoCancelDays` only when `clearAutoCancelDays` is off. (https://github.com/hotwax/order-routing-rules/issues/158#issuecomment-2042279565)


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
After:

![image](https://github.com/hotwax/order-routing-rules/assets/41404838/4e11753e-64d5-4366-a77e-284b842cd420)



### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/order-routing-rules#contribution-guideline)