### PR TITLE
Fixed: operator when selecting proximity filter

### DIFF
--- a/src/views/BrokeringQuery.vue
+++ b/src/views/BrokeringQuery.vue
@@ -701,7 +701,8 @@ async function selectValue(id: string, header: string) {
     if(!result.role && value) {
       filter.fieldValue = value
       // When selecting a filter value making the operator to default `equals` if not present already
-      filter.operator = filter.operator || "equals"
+      // For proximity filter we need to have less-equals as operator
+      filter.operator = (id === "PROXIMITY" ? "less-equals" : filter.operator || "equals")
       updateRule()
     }
   })


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
When applying proximity filter the operator passed is `equals` but we don't need the distance calculation logic to check for exact distance.

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Changed the operator for proximity filter to `less-equals` as we need to check for all the facilities withing that specified distance.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/order-routing-rules#contribution-guideline)