### PR TITLE
Improved: UI for the promise date order filter(#155)

### DIFF
--- a/src/views/BrokeringQuery.vue
+++ b/src/views/BrokeringQuery.vue
@@ -55,8 +55,7 @@
             <ion-item v-if="getFilterValue(orderRoutingFilterOptions, ruleEnums, 'PROMISE_DATE')">
               <ion-label>{{ translate("Promise date") }}</ion-label>
               <ion-chip outline @click="selectPromiseFilterValue($event)">
-                <!-- TODO: need to display a string in place of just the value -->
-                {{ getFilterValue(orderRoutingFilterOptions, ruleEnums, "PROMISE_DATE").fieldValue || getFilterValue(orderRoutingFilterOptions, ruleEnums, "PROMISE_DATE").fieldValue == 0 ? getFilterValue(orderRoutingFilterOptions, ruleEnums, "PROMISE_DATE").fieldValue : translate("select range") }}
+                {{ getPromiseDateValue() }}
               </ion-chip>
             </ion-item>
             <ion-item v-if="getFilterValue(orderRoutingFilterOptions, ruleEnums, 'SALES_CHANNEL')">
@@ -633,6 +632,14 @@ function isPromiseDateFilterApplied() {
   return filter?.fieldValue || filter?.fieldValue == 0
 }
 
+function getPromiseDateValue() {
+  const value = orderRoutingFilterOptions.value?.[ruleEnums["PROMISE_DATE"].code]?.fieldValue
+  if(value || value == 0) {
+    return value == 0 ? "already passed" : value.startsWith("-") ? `${value.replace("-", "")} days passed` : `upcoming in ${value} days`
+  }
+  return "select range"
+}
+
 function getFilterValue(options: any, enums: any, parameter: string) {
   return options?.[enums[parameter].code]
 }
@@ -666,6 +673,9 @@ async function selectPromiseFilterValue(ev: CustomEvent) {
   const popover = await popoverController
     .create({
       component: PromiseFilterPopover,
+      componentProps: {
+        value: getFilterValue(orderRoutingFilterOptions.value, ruleEnums, "PROMISE_DATE").fieldValue
+      },
       event: ev,
       translucent: true,
       showBackdrop: true


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added support to display a string in place of just a number when value is available
- Displayed already entered value in the alert input 
- Displayed the specific popover option highlighted if selected

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
After:

![image](https://github.com/hotwax/order-routing-rules/assets/41404838/87c055e7-10e6-4766-9b32-32b4dcabcfd0)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/order-routing-rules#contribution-guideline)