### PR TITLE
Fixed: the 12-hour format issue when using specific formatting options from luxon(#188)

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -34,7 +34,7 @@ const sortSequence = (sequence: Array<Group | Route | Rule>, sortOnField = "sequ
 }
 
 const getTime = (time: any) => {
-  // Directly using TIME_SIMPLE for formatting the time does not work, as the Intl is set in that way. So, using hourCycle to always get the time in 12-hour format
+  // Directly using TIME_SIMPLE for formatting the time results the time always in 24-hour format, as the Intl is set in that way. So, using hourCycle to always get the time in 12-hour format
   // https://github.com/moment/luxon/issues/998
   return time ? DateTime.fromMillis(time).toLocaleString({ ...DateTime.TIME_SIMPLE, hourCycle: "h12" }) : "-";
 }
@@ -48,8 +48,9 @@ function getDateAndTime(time: any) {
 }
 
 function getDateAndTimeShort(time: any) {
-  // format: hh:mm(localized 24-hour time) date/month
-  return time ? DateTime.fromMillis(time).toFormat("T dd/LL") : "-";
+  // format: hh:mm(localized 12-hour time) date/month
+  // Using toLocaleString as toFormat is not converting the time in 12-hour format
+  return time ? DateTime.fromMillis(time).toLocaleString({ hour: "numeric", minute: "numeric", day: "numeric", month: "numeric", hourCycle: "h12" }) : "-";
 }
 
 function timeTillRun(endTime: any) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -34,15 +34,17 @@ const sortSequence = (sequence: Array<Group | Route | Rule>, sortOnField = "sequ
 }
 
 const getTime = (time: any) => {
-  return time ? DateTime.fromMillis(time).toLocaleString(DateTime.TIME_SIMPLE) : "-";
+  // Directly using TIME_SIMPLE for formatting the time does not work, as the Intl is set in that way. So, using hourCycle to always get the time in 12-hour format
+  // https://github.com/moment/luxon/issues/998
+  return time ? DateTime.fromMillis(time).toLocaleString({ ...DateTime.TIME_SIMPLE, hourCycle: "h12" }) : "-";
 }
 
 function getDate(runTime: any) {
-  return DateTime.fromMillis(runTime).toLocaleString(DateTime.DATE_MED);
+  return DateTime.fromMillis(runTime).toLocaleString({ ...DateTime.DATE_MED, hourCycle: "h12" });
 }
 
 function getDateAndTime(time: any) {
-  return time ? DateTime.fromMillis(time).toLocaleString(DateTime.DATETIME_MED) : "-";
+  return time ? DateTime.fromMillis(time).toLocaleString({ ...DateTime.DATETIME_MED, hourCycle: "h12" }) : "-";
 }
 
 function getDateAndTimeShort(time: any) {

--- a/src/views/BrokeringRuns.vue
+++ b/src/views/BrokeringRuns.vue
@@ -113,6 +113,10 @@ onIonViewWillEnter(async () => {
 })
 
 function timeTillRun(time: any) {
+  if(!time) {
+    return;
+  }
+
   const timeDiff = DateTime.fromMillis(time).diff(DateTime.local());
   return DateTime.local().plus(timeDiff).toRelative();
 }

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -142,7 +142,7 @@ function logout() {
 }
 
 function getDateTime(time: any) {
-  return time ? DateTime.fromMillis(time).toLocaleString(DateTime.DATETIME_MED) : "";
+  return time ? DateTime.fromMillis(time).toLocaleString({ ...DateTime.DATETIME_MED, hourCycle: "h12" }) : "";
 }
 
 function goToOms() {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related Issue #118 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
As Intl is set in 24-hour format and luxon uses the format set at Intl does it was returning the time in 24-hour format. Overridden the behaviour by adding hourCycle property to always use 12-hour format.

- Also added a check to not result in error when time is undefined.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

After:

![image](https://github.com/hotwax/order-routing-rules/assets/41404838/6003bb35-23d8-4c1e-a829-328d813721f4)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/order-routing-rules#contribution-guideline)