### PR TITLE
Fixed: case to have a default value for cronExpression when updating group status and cron expresssion is not present

### DIFF
--- a/src/views/BrokeringRoute.vue
+++ b/src/views/BrokeringRoute.vue
@@ -477,12 +477,14 @@ async function updateGroupStatus(event: CustomEvent) {
 
   const payload = {
     routingGroupId: props.routingGroupId,
-    paused: job.value.paused
+    paused: job.value.paused,
+    cronExpression: job.value.cronExpression || "0 0 0 * * ?"
   }
 
   try {
     const resp = await OrderRoutingService.scheduleBrokering(payload)
     if(!hasError(resp)){
+      job.value.cronExpression = job.value.cronExpression || "0 0 0 * * ?"
       showToast(translate("Group status updated"))
     } else {
       throw resp.data


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->


### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
When changing the status of a group to active, and if the schedule is not set for the group then making the default value for the schedule to EveryDay at mid-night

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/order-routing-rules#contribution-guideline)