### PR TITLE
Fixed: issue regarding decimal numbers can be entered in alert input(#197)

### DIFF
--- a/src/components/PromiseFilterPopover.vue
+++ b/src/components/PromiseFilterPopover.vue
@@ -53,7 +53,13 @@ async function updatePromiseDate(header = '', isPastDuration = false) {
       placeholder: translate("duration"),
       min: 0,
       type: "number",
-      value: props.value?.replace("-", "")
+      value: props.value > 0 && !isPastDuration ? props.value : props.value < 0 && isPastDuration ? props.value?.replace("-", "") : '', // Prefill the value only when the previously selected option and current selection matches
+      attributes: {
+        // Added check to not allow mainly .(period) and other special characters to be entered in the alert input
+        onkeydown: ($event: any) => {
+          if(/[`!@#$%^&*()_+\-=\\|,.<>?~]/.test($event.key)) $event.preventDefault();
+        }
+      }
     }]
   })
 

--- a/src/views/BrokeringQuery.vue
+++ b/src/views/BrokeringQuery.vue
@@ -705,7 +705,13 @@ async function updateAutoCancelDays() {
       placeholder: translate("auto cancel days"),
       type: "number",
       min: 0,
-      value: inventoryRuleActions.value[actionEnums["AUTO_CANCEL_DAYS"].id]?.actionValue
+      value: inventoryRuleActions.value[actionEnums["AUTO_CANCEL_DAYS"].id]?.actionValue,
+      attributes: {
+        // Added check to not allow mainly .(period) and other special characters to be entered in the alert input
+        onkeydown: ($event: any) => {
+          if(/[`!@#$%^&*()_+\-=\\|,.<>?~]/.test($event.key)) $event.preventDefault();
+        }
+      }
     }],
     buttons: [{
       text: translate("Cancel"),
@@ -726,10 +732,8 @@ async function updateAutoCancelDays() {
             }
           }
         } else {
-          // If we have received an empty/undefined value for autoCancelDays then considered that it needs to be removed
-          if(inventoryRuleActions.value[actionEnums["AUTO_CANCEL_DAYS"].id]?.actionValue) {
-            delete inventoryRuleActions.value[actionEnums["AUTO_CANCEL_DAYS"].id]
-          }
+          showToast(translate("Enter a valid value"))
+          return false;
         }
         updateRule()
       }


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related Issue #197 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added check to not allow entering special characters in the alert input field
- Added support to only show the prefill values in promise date filter when the previously selected option and current option matches

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/order-routing-rules#contribution-guideline)