### PR TITLE
Fixed: archived routing cards to be dispalyed correctly after unarchiving a rule(#181)

### DIFF
--- a/src/components/ArchivedRoutingModal.vue
+++ b/src/components/ArchivedRoutingModal.vue
@@ -72,6 +72,6 @@ async function updateOrderRouting(routing: Route, fieldToUpdate: string, value: 
   props.saveRoutings([{
     ...routing,
     [fieldToUpdate]: value
-  }])
+  }, ...routings.value])
 }
 </script>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related Issue #181

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
When unarchiving, we are only updating the current route and not updating all the routes, thus updated all the routings on unarhive.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/order-routing-rules#contribution-guideline)