### PR TITLE
Fixed: case to handle the case when enum data is missing for specific type

### DIFF
--- a/src/components/AddInventoryFilterOptionsModal.vue
+++ b/src/components/AddInventoryFilterOptionsModal.vue
@@ -9,7 +9,10 @@
       </ion-toolbar>
     </ion-header>
     <ion-content>
-      <ion-list>
+      <div v-if="!enumerations.length" class="empty-state">
+        <p>{{ translate(`Failed to fetch ${props.label?.toLowerCase()} options`) }}</p>
+      </div>
+      <ion-list v-else>
         <ion-item v-for="condition in enumerations" :key="condition.enumId">
           <ion-checkbox :checked="isConditionOptionSelected(condition.enumCode)" @ionChange="addConditionOption(condition)">{{ condition.description || condition.enumCode }}</ion-checkbox>
         </ion-item>
@@ -66,7 +69,7 @@ const associatedOptions = { IIP_PROXIMITY: { enum: "IIP_MSMNT_SYSTEM", defaultVa
 
 onMounted(() => {
   inventoryRuleConditions.value = props.ruleConditions ? JSON.parse(JSON.stringify(props.ruleConditions)) : {}
-  enumerations.value = Object.values(enums.value[props.parentEnumId]).filter((enumeration: any) => !hiddenOptions.includes(enumeration.enumId))
+  enumerations.value = enums.value[props.parentEnumId] ? Object.values(enums.value[props.parentEnumId]).filter((enumeration: any) => !hiddenOptions.includes(enumeration.enumId)) : []
 })
 
 function checkFilters() {

--- a/src/components/AddOrderRouteFilterOptions.vue
+++ b/src/components/AddOrderRouteFilterOptions.vue
@@ -9,8 +9,11 @@
       </ion-toolbar>
     </ion-header>
     <ion-content>
-      <ion-list>
-        <ion-item v-for="sort in Object.values(enums[props.parentEnumId] ? enums[props.parentEnumId] : {})" :key="sort.enumId">
+      <div v-if="!enums[props.parentEnumId]" class="empty-state">
+        <p>{{ translate(`Failed to fetch ${$props.label?.toLowerCase()} options`) }}</p>
+      </div>
+      <ion-list v-else>
+        <ion-item v-for="sort in Object.values(enums[props.parentEnumId])" :key="sort.enumId">
           <ion-checkbox :checked="isSortOptionSelected(sort.enumCode)" @ionChange="addSortOption(sort)">{{ sort.description || sort.enumCode }}</ion-checkbox>
         </ion-item>
       </ion-list>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -48,6 +48,8 @@
   "Failed to create brokering run": "Failed to create brokering run",
   "Failed to create inventory rule": "Failed to create inventory rule",
   "Failed to create order routing": "Failed to create order routing",
+  "Failed to fetch filter options": "Failed to fetch filter options",
+  "Failed to fetch sort options": "Failed to fetch sort options",
   "Failed to update group information": "Failed to update group information",
   "Failed to update group status": "Failed to update group status",
   "Failed to schedule service": "Failed to schedule service",

--- a/src/views/BrokeringQuery.vue
+++ b/src/views/BrokeringQuery.vue
@@ -793,7 +793,7 @@ function getSelectedValue(options: any, enumerations: any, parameter: string) {
 
 function getLabel(parentType: string, code: string) {
   const enumerations = enums.value[parentType]
-  const enumInfo: any = Object.values(enumerations).find((enumeration: any) => enumeration.enumCode === code)
+  const enumInfo: any = enumerations ? Object.values(enumerations).find((enumeration: any) => enumeration.enumCode === code) : null
 
   return enumInfo?.description
 }

--- a/src/views/BrokeringQuery.vue
+++ b/src/views/BrokeringQuery.vue
@@ -770,7 +770,7 @@ function getPromiseDateValue() {
 }
 
 function getFilterValue(options: any, enums: any, parameter: string) {
-  return options?.[enums[parameter].code]
+  return enums[parameter] ? options?.[enums[parameter].code] : undefined
 }
 
 function getSelectedValue(options: any, enumerations: any, parameter: string) {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
If the enum data is missing then the label for the sort options is not displayed and the option selection modal is displayed empty.

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added empty state in option selection modal when the enum data is missing
- Added check to display the code if the enum label is missing

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
Before:

![image](https://github.com/hotwax/order-routing-rules/assets/41404838/e9e75561-f78d-4d11-afe0-12d96920fa0f)


After:

![image](https://github.com/hotwax/order-routing-rules/assets/41404838/b55ace1e-1306-4b9a-be08-1c70ff6396a0)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/order-routing-rules#contribution-guideline)