### PR TITLE
Fixed: issue of duplicate filters getting applied on the rules

### DIFF
--- a/src/views/BrokeringQuery.vue
+++ b/src/views/BrokeringQuery.vue
@@ -527,7 +527,7 @@ async function updateRouteName() {
   isRouteNameUpdating.value = false
 }
 
-async function fetchRuleInformation(routingRuleId: string) {
+async function fetchRuleInformation(routingRuleId: string, forceUpdate = false) {
   // Changing the value to false, as when fetching the information initially or after changing the rule we should stop the process of name updation
   isRuleNameUpdating.value = false
 
@@ -535,12 +535,12 @@ async function fetchRuleInformation(routingRuleId: string) {
 
   // When clicking the same enum again do not fetch its information
   // TODO: check behaviour when creating a new rule, when no rule exist and when already some rule exist and a rule is open
-  if(selectedRoutingRule.value.routingRuleId === routingRuleId) {
+  if(selectedRoutingRule.value.routingRuleId === routingRuleId && !forceUpdate) {
     return;
   }
 
   // Only fetch the rules information, if already not present, as we are updating rule values
-  if(!rulesInformation.value[routingRuleId]) {
+  if(!rulesInformation.value[routingRuleId] || forceUpdate) {
     rulesInformation.value[routingRuleId] = await store.dispatch("orderRouting/fetchInventoryRuleInformation", routingRuleId)
   }
 
@@ -1307,7 +1307,9 @@ async function save() {
   // Added check to not fetch any rule related information as when a new route will be created no rule will be available thus no need to fetch any other information
   if(currentRouting.value["rules"]?.length) {
     inventoryRules.value = sortSequence(JSON.parse(JSON.stringify(currentRouting.value["rules"])))
-    await fetchRuleInformation(currentRuleId.value);
+    // Passed true as when updating an existing rule we get seqIds in the response so to fetch the latest seqIds for the rule calling rule api again by passing true
+    // TODO: Need to update this logic by just updating the state instead of making an api call, this can also be handled when in the update api call we will get latest information again
+    await fetchRuleInformation(currentRuleId.value, true);
   }
 
   hasUnsavedChanges.value = false


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
This issue occurs when we apply a new condition in the rule and update the same condition without refresh.

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fetched the latest information after updating a rule so to pass the seqId when updating the same filter again

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/order-routing-rules#contribution-guideline)