### PR TITLE
Implemented: support to unselect the action type for inventory rule

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -97,6 +97,7 @@
   "No run history": "No run history",
   "No runs scheduled": "No runs scheduled",
   "No time zone found": "No time zone found",
+  "None": "None",
   "OMS": "OMS",
   "OMS instance": "OMS instance",
   "Order batches": "Order batches",

--- a/src/views/BrokeringQuery.vue
+++ b/src/views/BrokeringQuery.vue
@@ -259,6 +259,9 @@
                         {{ translate("Queue") }}
                         <ion-icon :icon="golfOutline"/>
                       </ion-select-option>
+                      <ion-select-option value="">
+                        {{ translate("None") }}
+                      </ion-select-option>
                     </ion-select>
                   </ion-item>
                   <ion-item lines="none" v-show="ruleActionType === actionEnums['MOVE_TO_QUEUE'].id">
@@ -688,11 +691,13 @@ function updateOrderRouting(value: string) {
 function updateUnfillableActionType(value: string) {
   const actionType = ruleActionType.value
   ruleActionType.value = value
-
-  inventoryRuleActions.value[ruleActionType.value] = {
-    actionTypeEnumId: value,
-    actionValue: "", // after changing action type, as next_rule action does not need to have a value, so in all cases making intially the value as empty and will update if required from some other function
-    createdDate: DateTime.now().toMillis()
+  // Create the new action type only when we have not selected none option, otherwise just delete the previous selected action type
+  if(value) {
+    inventoryRuleActions.value[ruleActionType.value] = {
+      actionTypeEnumId: value,
+      actionValue: "", // after changing action type, as next_rule action does not need to have a value, so in all cases making intially the value as empty and will update if required from some other function
+      createdDate: DateTime.now().toMillis()
+    }
   }
   // deleting previous action type, but using the data of previous action
   delete inventoryRuleActions.value[actionType]


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
Currently we don't have an option to remove a rule action type from the rule once selected, so need to have an option so that user can remove the rule action type from the rule.

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Added a `None` option in rule actions to remove it from the rule

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/order-routing-rules#contribution-guideline)