### PR TITLE
Fixed: Prevented pointer cursor and click events on ion-item (#169)

### DIFF
--- a/src/views/BrokeringQuery.vue
+++ b/src/views/BrokeringQuery.vue
@@ -293,7 +293,7 @@
                         <ion-select-option v-for="(facilityGroup, facilityGroupId) in getFacilityGroupsForBrokering()" :key="facilityGroupId" :value="facilityGroupId" :disabled="isFacilityGroupSelected(facilityGroupId, 'excluded')">{{ facilityGroup.facilityGroupName || facilityGroupId }}</ion-select-option>
                       </ion-select>
                     </ion-item>
-                    <ion-item v-if="getFilterValue(inventoryRuleFilterOptions, conditionFilterEnums, 'PROXIMITY')">
+                    <ion-item class="disable-pointer-events" v-if="getFilterValue(inventoryRuleFilterOptions, conditionFilterEnums, 'PROXIMITY')">
                       <!-- TODO: Confirm on the possible options -->
                       <ion-label>{{ translate("Proximity") }}</ion-label>
                       <div>
@@ -306,7 +306,7 @@
                         <ion-chip outline @click="selectValue('PROXIMITY', 'Add proximity')">{{ getFilterValue(inventoryRuleFilterOptions, conditionFilterEnums, "PROXIMITY").fieldValue || getFilterValue(inventoryRuleFilterOptions, conditionFilterEnums, "PROXIMITY").fieldValue == 0 ? getFilterValue(inventoryRuleFilterOptions, conditionFilterEnums, "PROXIMITY").fieldValue : "-" }}</ion-chip>
                       </div>
                     </ion-item>
-                    <ion-item v-if="getFilterValue(inventoryRuleFilterOptions, conditionFilterEnums, 'BRK_SAFETY_STOCK')">
+                    <ion-item class="disable-pointer-events" v-if="getFilterValue(inventoryRuleFilterOptions, conditionFilterEnums, 'BRK_SAFETY_STOCK')">
                       <ion-label>{{ translate("Brokering safety stock") }}</ion-label>
                       <div>
                         <ion-chip outline @click.stop="chipClickEvent(operatorRef)">
@@ -1703,5 +1703,14 @@ ion-chip > ion-select {
 
 .rule-item {
   transition: .5s all ease;
+}
+/* Sets default cursor and disables pointer interactions. */
+.disable-pointer-events {  
+  cursor: default;
+  pointer-events: none;
+}
+/* Re-enables pointer interactions on ion-chip elements within ion-item. */
+ion-item ion-chip {
+  pointer-events: auto;
 }
 </style>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#169 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- The ion-item contains an ion-select element within an ion-chip. The presence of this `interactive control` (ion-select) is the reason why Ionic dynamically adds the `.item-has-interactive-control` class to the ion-item, resulting in the pointer cursor. 
- Added `cursor: default` and `pointer-events: none` on the `ion-item` to prevent the pointer cursor and click events on its background, while `pointer-events: auto` was applied to the nested `ion-chip` to maintain its interactivity.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/order-routing-rules#contribution-guideline)