### PR TITLE
Improved:show custom expression string on list page (#293)

### DIFF
--- a/src/views/BrokeringRuns.vue
+++ b/src/views/BrokeringRuns.vue
@@ -177,19 +177,17 @@ async function setEComStore(event: CustomEvent) {
 }
 
 function getScheduleFrequency(brokeringGroupObj: any) {
-  let cronDescription = "-";
-  let description = Object.entries(cronExpressions).find(([description, expression]) => expression === brokeringGroupObj.cronExpression)?.[0]
-  if (description) cronDescription = description;
-  
-  if (brokeringGroupObj.cronDescription) {
-    description = cronstrue.toString(brokeringGroupObj.cronExpression)
-    // Capitalize the first letter if it's not a number or symbol
+  let description: any = "";
+  description = Object.keys(cronExpressions).find(key => cronExpressions[key] === brokeringGroupObj.cronExpression);
+
+  if (!description && brokeringGroupObj.cronExpression) {
+    description = cronstrue.toString(brokeringGroupObj.cronExpression);
+    // Capitalize first letter if it starts with a lowercase letter
     if (/^[a-z]/.test(description)) {
       description = description.charAt(0).toUpperCase() + description.slice(1);
     }
-    cronDescription = description;
   }
-  return cronDescription;
+  return description || "-";
 }
 
 function redirect(group: Group) {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#293 : show custom expression string on list page

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
On the list page, if a routing has a custom expression set, it doesn't show the description of the schedule


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/order-routing-rules#contribution-guideline)