### PR TITLE
Fixed: relocate loader presentation logic from order routing action to view lifecycle hook

### DIFF
--- a/src/store/modules/orderRouting/actions.ts
+++ b/src/store/modules/orderRouting/actions.ts
@@ -80,7 +80,6 @@ const actions: ActionTree<OrderRoutingState, RootState> = {
   },
 
   async fetchCurrentRoutingGroup({ dispatch }, routingGroupId) {
-    emitter.emit("presentLoader", { message: "Fetching rules", backdropDismiss: false })
     let currentGroup = {} as any
 
     try {
@@ -101,8 +100,6 @@ const actions: ActionTree<OrderRoutingState, RootState> = {
 
     // Fetching the schedule information for the group
     await dispatch("fetchCurrentGroupSchedule", { routingGroupId, currentGroup })
-
-    emitter.emit("dismissLoader")
   },
 
   async fetchCurrentGroupSchedule({ commit }, payload) {

--- a/src/views/BrokeringRoute.vue
+++ b/src/views/BrokeringRoute.vue
@@ -272,6 +272,7 @@ const currentEComStore = computed(() => store.getters["user/getCurrentEComStore"
 const userProfile = computed(() => store.getters["user/getUserProfile"])
 
 onIonViewWillEnter(async () => {
+  emitter.emit("presentLoader", { message: "Fetching rules", backdropDismiss: false })
   await store.dispatch("orderRouting/fetchCurrentRoutingGroup", props.routingGroupId)
   await fetchGroupHistory()
   store.dispatch("orderRouting/fetchRoutingHistory", props.routingGroupId)
@@ -288,6 +289,7 @@ onIonViewWillEnter(async () => {
   if(orderRoutings.value.length) {
     initializeOrderRoutings();
   }
+  emitter.emit("dismissLoader")
 })
 
 onBeforeRouteLeave(async (to) => {
@@ -734,7 +736,7 @@ async function saveRoutingGroup() {
 }
 
 async function updateRoutingGroup(payload: any) {
-  emitter.emit("presentLoader", { message: "Updating...", backdropDismiss: false })
+  emitter.emit("presentLoader", { message: "Updating... ", backdropDismiss: false })
   let routingGroupId = ''
   try {
     const resp = await OrderRoutingService.updateRoutingGroup(payload);

--- a/src/views/BrokeringRoute.vue
+++ b/src/views/BrokeringRoute.vue
@@ -736,7 +736,7 @@ async function saveRoutingGroup() {
 }
 
 async function updateRoutingGroup(payload: any) {
-  emitter.emit("presentLoader", { message: "Updating... ", backdropDismiss: false })
+  emitter.emit("presentLoader", { message: "Updating...", backdropDismiss: false })
   let routingGroupId = ''
   try {
     const resp = await OrderRoutingService.updateRoutingGroup(payload);


### PR DESCRIPTION
closes: #305 