### PR TITLE
Migrate deprecated order-routing common APIs to admin

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -83,13 +83,20 @@ const api = async (customConfig: any) => {
     method: customConfig.method,
     data: customConfig.data,
     params: customConfig.params,
+    headers: customConfig.headers,
     // withCredentials: true
   }
 
   const baseURL = store.getters["user/getInstanceUrl"];
 
   if (baseURL) {
-    config.baseURL = baseURL.startsWith('http') ? baseURL.includes('/rest/s1/order-routing') ? baseURL : `${baseURL}/rest/s1/order-routing/` : `https://${baseURL}.hotwax.io/rest/s1/order-routing/`;
+    if (customConfig.url?.startsWith("admin/")) {
+      config.baseURL = baseURL.startsWith('http')
+        ? baseURL.includes('/rest/s1/order-routing') ? baseURL.replace(/\/order-routing\/?$/, "/") : baseURL.includes('/rest/s1') ? baseURL : `${baseURL}/rest/s1/`
+        : `https://${baseURL}.hotwax.io/rest/s1/`;
+    } else {
+      config.baseURL = baseURL.startsWith('http') ? baseURL.includes('/rest/s1/order-routing') ? baseURL : `${baseURL}/rest/s1/order-routing/` : `https://${baseURL}.hotwax.io/rest/s1/order-routing/`;
+    }
   }
   
   if(customConfig.cache) config.adapter = axiosCache.adapter;

--- a/src/services/RoutingService.ts
+++ b/src/services/RoutingService.ts
@@ -3,25 +3,6 @@ import logger from "@/logger";
 import store from "@/store";
 import { getOmsRedirectionUrl, hasError } from "@/utils";
 
-const getAdminBaseURL = (): string => {
-  const url = store.getters["user/getBaseUrl"]
-  if (url.startsWith("http")) {
-    return url.includes("/rest/s1/order-routing")
-      ? url.replace(/\/rest\/s1\/order-routing\/?$/, "/rest/s1/admin/")
-      : `${url}/rest/s1/admin/`;
-  }
-  return `https://${url}.hotwax.io/rest/s1/admin/`;
-}
-
-const getAdminHeaders = () => {
-  const token = store.getters["user/getUserToken"]
-  return {
-    Api_Key: token,
-    Authorization: "Bearer " + token,
-    "Content-Type": "application/json"
-  }
-}
-
 const fetchRoutingGroups = async (payload: any): Promise<any> => {
   return api({
     url: "groups", 
@@ -53,11 +34,9 @@ const fetchRoutingHistory = async (routingGroupId: string, params: any): Promise
 }
 
 const fetchGroupHistory = async (jobName: string, params: any): Promise<any> => {
-  return client({
-    url: `serviceJobs/${jobName}/runs`,
+  return api({
+    url: `admin/serviceJobs/${jobName}/runs`,
     method: "GET",
-    baseURL: getAdminBaseURL(),
-    headers: getAdminHeaders(),
     params
   });
 }

--- a/src/services/RoutingService.ts
+++ b/src/services/RoutingService.ts
@@ -3,6 +3,25 @@ import logger from "@/logger";
 import store from "@/store";
 import { getOmsRedirectionUrl, hasError } from "@/utils";
 
+const getAdminBaseURL = (): string => {
+  const url = store.getters["user/getBaseUrl"]
+  if (url.startsWith("http")) {
+    return url.includes("/rest/s1/order-routing")
+      ? url.replace(/\/rest\/s1\/order-routing\/?$/, "/rest/s1/admin/")
+      : `${url}/rest/s1/admin/`;
+  }
+  return `https://${url}.hotwax.io/rest/s1/admin/`;
+}
+
+const getAdminHeaders = () => {
+  const token = store.getters["user/getUserToken"]
+  return {
+    Api_Key: token,
+    Authorization: "Bearer " + token,
+    "Content-Type": "application/json"
+  }
+}
+
 const fetchRoutingGroups = async (payload: any): Promise<any> => {
   return api({
     url: "groups", 
@@ -34,9 +53,11 @@ const fetchRoutingHistory = async (routingGroupId: string, params: any): Promise
 }
 
 const fetchGroupHistory = async (jobName: string, params: any): Promise<any> => {
-  return api({
-    url: `serviceJobRuns/${jobName}`,
+  return client({
+    url: `serviceJobs/${jobName}/runs`,
     method: "GET",
+    baseURL: getAdminBaseURL(),
+    headers: getAdminHeaders(),
     params
   });
 }

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -2,16 +2,24 @@ import api, { client } from "@/api"
 import store from "@/store";
 import { hasError } from "@/utils";
 
+const getAdminBaseURL = (): string => {
+  const url = store.getters["user/getBaseUrl"];
+  if (url.startsWith("http")) {
+    return url.includes("/rest/s1/order-routing")
+      ? url.replace(/\/rest\/s1\/order-routing\/?$/, "/rest/s1/admin/")
+      : `${url}/rest/s1/admin/`;
+  }
+  return `https://${url}.hotwax.io/rest/s1/admin/`;
+}
+
 const login = async (token: string): Promise <any> => {
-  const url = store.getters["user/getBaseUrl"]
-  const baseURL = url.startsWith('http') ? url.includes('/rest/s1/order-routing') ? url : `${url}/rest/s1/order-routing/` : `https://${url}.hotwax.io/rest/s1/order-routing/`;
   let api_key = ""
 
   try {
     const resp = await client({
       url: "login", 
       method: "post",
-      baseURL,
+      baseURL: getAdminBaseURL(),
       params: {
         token
       },
@@ -122,13 +130,11 @@ const getUserPermissions = async (payload: any, url: string, token: any): Promis
 }
 
 const getUserProfile = async (token: any): Promise<any> => {
-  const url = store.getters["user/getBaseUrl"]
-  const baseURL = url.startsWith('http') ? url.includes('/rest/s1/order-routing') ? url : `${url}/rest/s1/order-routing/` : `https://${url}.hotwax.io/rest/s1/order-routing/`;
   try {
     const resp = await client({
       url: "user/profile",
       method: "GET",
-      baseURL,
+      baseURL: getAdminBaseURL(),
       headers: {
         "api_key": token,
         "Content-Type": "application/json"
@@ -143,12 +149,10 @@ const getUserProfile = async (token: any): Promise<any> => {
 
 const getEComStores = async (token: any): Promise<any> => {
   try {
-    const url = store.getters["user/getBaseUrl"]
-    const baseURL = url.startsWith('http') ? url.includes('/rest/s1/order-routing') ? url : `${url}/rest/s1/order-routing/` : `https://${url}.hotwax.io/rest/s1/order-routing/`;
     const resp = await client({
       url: "user/productStore",
       method: "GET",
-      baseURL,
+      baseURL: getAdminBaseURL(),
       headers: {
         "api_key": token,
         "Content-Type": "application/json"
@@ -166,10 +170,15 @@ const getEComStores = async (token: any): Promise<any> => {
 }
 
 const getAvailableTimeZones = async (): Promise <any>  => {
-  return api({
+  const token = store.getters["user/getUserToken"]
+  return client({
     url: "user/getAvailableTimeZones",
     method: "get",
-    cache: true
+    baseURL: getAdminBaseURL(),
+    headers: {
+      "api_key": token,
+      "Content-Type": "application/json"
+    }
   });
 }
 const setUserTimeZone = async (payload: any): Promise <any>  => {

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -2,24 +2,13 @@ import api, { client } from "@/api"
 import store from "@/store";
 import { hasError } from "@/utils";
 
-const getAdminBaseURL = (): string => {
-  const url = store.getters["user/getBaseUrl"];
-  if (url.startsWith("http")) {
-    return url.includes("/rest/s1/order-routing")
-      ? url.replace(/\/rest\/s1\/order-routing\/?$/, "/rest/s1/admin/")
-      : `${url}/rest/s1/admin/`;
-  }
-  return `https://${url}.hotwax.io/rest/s1/admin/`;
-}
-
 const login = async (token: string): Promise <any> => {
   let api_key = ""
 
   try {
-    const resp = await client({
-      url: "login", 
+    const resp = await api({
+      url: "admin/login",
       method: "post",
-      baseURL: getAdminBaseURL(),
       params: {
         token
       },
@@ -131,10 +120,9 @@ const getUserPermissions = async (payload: any, url: string, token: any): Promis
 
 const getUserProfile = async (token: any): Promise<any> => {
   try {
-    const resp = await client({
-      url: "user/profile",
+    const resp = await api({
+      url: "admin/user/profile",
       method: "GET",
-      baseURL: getAdminBaseURL(),
       headers: {
         "api_key": token,
         "Content-Type": "application/json"
@@ -149,10 +137,9 @@ const getUserProfile = async (token: any): Promise<any> => {
 
 const getEComStores = async (token: any): Promise<any> => {
   try {
-    const resp = await client({
-      url: "user/productStore",
+    const resp = await api({
+      url: "admin/user/productStore",
       method: "GET",
-      baseURL: getAdminBaseURL(),
       headers: {
         "api_key": token,
         "Content-Type": "application/json"
@@ -170,15 +157,10 @@ const getEComStores = async (token: any): Promise<any> => {
 }
 
 const getAvailableTimeZones = async (): Promise <any>  => {
-  const token = store.getters["user/getUserToken"]
-  return client({
-    url: "user/getAvailableTimeZones",
+  return api({
+    url: "admin/user/getAvailableTimeZones",
     method: "get",
-    baseURL: getAdminBaseURL(),
-    headers: {
-      "api_key": token,
-      "Content-Type": "application/json"
-    }
+    cache: true
   });
 }
 const setUserTimeZone = async (payload: any): Promise <any>  => {

--- a/src/services/UtilService.ts
+++ b/src/services/UtilService.ts
@@ -3,51 +3,26 @@ import logger from "@/logger";
 import store from "@/store";
 import { getOmsRedirectionUrl } from "@/utils";
 
-const getAdminBaseURL = (): string => {
-  const url = store.getters["user/getBaseUrl"]
-  if (url.startsWith("http")) {
-    return url.includes("/rest/s1/order-routing")
-      ? url.replace(/\/rest\/s1\/order-routing\/?$/, "/rest/s1/admin/")
-      : `${url}/rest/s1/admin/`;
-  }
-  return `https://${url}.hotwax.io/rest/s1/admin/`;
-}
-
-const getAdminHeaders = () => {
-  const token = store.getters["user/getUserToken"]
-  return {
-    Api_Key: token,
-    Authorization: "Bearer " + token,
-    "Content-Type": "application/json"
-  }
-}
-
 const fetchEnums = async (payload: any): Promise<any> => {
-  return client({
-    url: "enums", 
+  return api({
+    url: "admin/enums",
     method: "GET",
-    baseURL: getAdminBaseURL(),
-    headers: getAdminHeaders(),
     params: payload
   });
 }
 
 const fetchOmsEnums = async (payload: any): Promise<any> => {
-  return client({
-    url: "enums",
+  return api({
+    url: "admin/enums",
     method: "GET",
-    baseURL: getAdminBaseURL(),
-    headers: getAdminHeaders(),
     params: payload
   });
 }
 
 const fetchFacilities = async (payload: any): Promise<any> => {
-  return client({
-    url: "facilities", 
+  return api({
+    url: "admin/facilities",
     method: "GET",
-    baseURL: getAdminBaseURL(),
-    headers: getAdminHeaders(),
     params: payload
   });
 }
@@ -61,31 +36,25 @@ const fetchCategories = async (payload: any): Promise<any> => {
 }
 
 const fetchShippingMethods = async (payload: any): Promise<any> => {
-  return client({
-    url: `productStores/${payload.productStoreId}/shippingMethods`,
+  return api({
+    url: `admin/productStores/${payload.productStoreId}/shippingMethods`,
     method: "GET",
-    baseURL: getAdminBaseURL(),
-    headers: getAdminHeaders(),
     params: payload
   });
 }
 
 const fetchFacilityGroups = async (payload: any): Promise<any> => {
-  return client({
-    url: `productStores/${payload.productStoreId}/facilityGroups`, 
+  return api({
+    url: `admin/productStores/${payload.productStoreId}/facilityGroups`,
     method: "GET",
-    baseURL: getAdminBaseURL(),
-    headers: getAdminHeaders(),
     params: payload
   });
 }
 
 const fetchStatusInformation = async (payload: any): Promise<any> => {
-  return client({
-    url: "status",
+  return api({
+    url: "admin/status",
     method: "GET",
-    baseURL: getAdminBaseURL(),
-    headers: getAdminHeaders(),
     params: payload
   });
 }
@@ -179,11 +148,9 @@ const getTestSessions = async(payload: any): Promise<any> => {
 const createUserSession = async (payload: any): Promise<any> => {
   let userTestingSession = {} as any;
   try {
-    const resp = await client({
-      url: "user/sessions",
+    const resp = await api({
+      url: "admin/user/sessions",
       method: "POST",
-      baseURL: getAdminBaseURL(),
-      headers: getAdminHeaders(),
       data: payload
     }) as any;
 
@@ -201,11 +168,9 @@ const createUserSession = async (payload: any): Promise<any> => {
 
 const expireUserSession = async(payload: any, userTestingSession = {}): Promise<any> => {
   try {
-    const resp = await client({
-      url: `user/sessions/${payload.userSessionId}`,
+    const resp = await api({
+      url: `admin/user/sessions/${payload.userSessionId}`,
       method: "PUT",
-      baseURL: getAdminBaseURL(),
-      headers: getAdminHeaders(),
       data: payload
     }) as any;
 
@@ -220,23 +185,19 @@ const expireUserSession = async(payload: any, userTestingSession = {}): Promise<
 }
 
 const updateProductStoreInfo = async (payload: any): Promise<any> => {
-  return client({
-    url: `productStores/${payload.productStoreId}`,
+  return api({
+    url: `admin/productStores/${payload.productStoreId}`,
     method: "PUT",
-    baseURL: getAdminBaseURL(),
-    data: payload,
-    headers: getAdminHeaders()
+    data: payload
   })
 }
 
 const getProductStoreInfo = async (): Promise<any> => {
   const productStoreId = store.getters["user/getCurrentEComStore"]?.productStoreId
 
-  return client({
-    url: `productStores/${productStoreId}`,
-    method: "GET",
-    baseURL: getAdminBaseURL(),
-    headers: getAdminHeaders()
+  return api({
+    url: `admin/productStores/${productStoreId}`,
+    method: "GET"
   })
 }
 

--- a/src/services/UtilService.ts
+++ b/src/services/UtilService.ts
@@ -3,26 +3,51 @@ import logger from "@/logger";
 import store from "@/store";
 import { getOmsRedirectionUrl } from "@/utils";
 
+const getAdminBaseURL = (): string => {
+  const url = store.getters["user/getBaseUrl"]
+  if (url.startsWith("http")) {
+    return url.includes("/rest/s1/order-routing")
+      ? url.replace(/\/rest\/s1\/order-routing\/?$/, "/rest/s1/admin/")
+      : `${url}/rest/s1/admin/`;
+  }
+  return `https://${url}.hotwax.io/rest/s1/admin/`;
+}
+
+const getAdminHeaders = () => {
+  const token = store.getters["user/getUserToken"]
+  return {
+    Api_Key: token,
+    Authorization: "Bearer " + token,
+    "Content-Type": "application/json"
+  }
+}
+
 const fetchEnums = async (payload: any): Promise<any> => {
-  return api({
+  return client({
     url: "enums", 
     method: "GET",
+    baseURL: getAdminBaseURL(),
+    headers: getAdminHeaders(),
     params: payload
   });
 }
 
 const fetchOmsEnums = async (payload: any): Promise<any> => {
-  return api({
-    url: "omsenums",
+  return client({
+    url: "enums",
     method: "GET",
+    baseURL: getAdminBaseURL(),
+    headers: getAdminHeaders(),
     params: payload
   });
 }
 
 const fetchFacilities = async (payload: any): Promise<any> => {
-  return api({
+  return client({
     url: "facilities", 
     method: "GET",
+    baseURL: getAdminBaseURL(),
+    headers: getAdminHeaders(),
     params: payload
   });
 }
@@ -36,25 +61,31 @@ const fetchCategories = async (payload: any): Promise<any> => {
 }
 
 const fetchShippingMethods = async (payload: any): Promise<any> => {
-  return api({
+  return client({
     url: `productStores/${payload.productStoreId}/shippingMethods`,
     method: "GET",
+    baseURL: getAdminBaseURL(),
+    headers: getAdminHeaders(),
     params: payload
   });
 }
 
 const fetchFacilityGroups = async (payload: any): Promise<any> => {
-  return api({
+  return client({
     url: `productStores/${payload.productStoreId}/facilityGroups`, 
     method: "GET",
+    baseURL: getAdminBaseURL(),
+    headers: getAdminHeaders(),
     params: payload
   });
 }
 
 const fetchStatusInformation = async (payload: any): Promise<any> => {
-  return api({
+  return client({
     url: "status",
     method: "GET",
+    baseURL: getAdminBaseURL(),
+    headers: getAdminHeaders(),
     params: payload
   });
 }
@@ -148,9 +179,11 @@ const getTestSessions = async(payload: any): Promise<any> => {
 const createUserSession = async (payload: any): Promise<any> => {
   let userTestingSession = {} as any;
   try {
-    const resp = await api({
+    const resp = await client({
       url: "user/sessions",
       method: "POST",
+      baseURL: getAdminBaseURL(),
+      headers: getAdminHeaders(),
       data: payload
     }) as any;
 
@@ -168,9 +201,11 @@ const createUserSession = async (payload: any): Promise<any> => {
 
 const expireUserSession = async(payload: any, userTestingSession = {}): Promise<any> => {
   try {
-    const resp = await api({
+    const resp = await client({
       url: `user/sessions/${payload.userSessionId}`,
       method: "PUT",
+      baseURL: getAdminBaseURL(),
+      headers: getAdminHeaders(),
       data: payload
     }) as any;
 
@@ -185,38 +220,23 @@ const expireUserSession = async(payload: any, userTestingSession = {}): Promise<
 }
 
 const updateProductStoreInfo = async (payload: any): Promise<any> => {
-  const url = store.getters["user/getBaseUrl"]
-  const token = store.getters["user/getUserToken"]
-  const baseURL = url.startsWith("http") ? url.includes("/rest/s1/order-routing") ? url.replace("/order-routing", "/oms") : `${url}/rest/s1/oms/` : `https://${url}.hotwax.io/rest/s1/oms/`;
-
   return client({
     url: `productStores/${payload.productStoreId}`,
     method: "PUT",
-    baseURL: baseURL,
+    baseURL: getAdminBaseURL(),
     data: payload,
-    headers: {
-      Api_Key: token,
-      Authorization: "Bearer " + token,
-      "Content-Type": "application/json"
-    }
+    headers: getAdminHeaders()
   })
 }
 
 const getProductStoreInfo = async (): Promise<any> => {
-  const url = store.getters["user/getBaseUrl"]
-  const token = store.getters["user/getUserToken"]
-  const baseURL = url.startsWith('http') ? url.includes('/rest/s1/order-routing') ? url.replace("/order-routing", "/oms") : `${url}/rest/s1/oms/` : `https://${url}.hotwax.io/rest/s1/oms/`;
   const productStoreId = store.getters["user/getCurrentEComStore"]?.productStoreId
 
   return client({
     url: `productStores/${productStoreId}`,
     method: "GET",
-    baseURL: baseURL,
-    headers: {
-      Api_Key: token,
-      Authorization: 'Bearer ' + token,
-      'Content-Type': 'application/json'
-    }
+    baseURL: getAdminBaseURL(),
+    headers: getAdminHeaders()
   })
 }
 


### PR DESCRIPTION
Refs hotwax/OrderRouting#116.

Migrates order-routing PWA calls for login, user/profile, enums, facilities, facility groups, status, product store info, sessions, and service job run history to admin APIs. Response handling was reviewed; `omsenums` now uses the admin `enums` resource with the same query contract.