### PR TITLE
Enable IDE Trace Vue plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@typescript-eslint/parser": "~5.26.0",
     "@vitejs/plugin-legacy": "catalog:",
     "@vitejs/plugin-vue": "catalog:",
+    "chrome-ide-trace": "^0.1.0",
     "@vue/eslint-config-typescript": "^9.1.0",
     "@vue/test-utils": "^2.0.0-0",
     "eslint": "catalog:",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@typescript-eslint/parser": "~5.26.0",
     "@vitejs/plugin-legacy": "catalog:",
     "@vitejs/plugin-vue": "catalog:",
-    "chrome-ide-trace": "^0.1.0",
+    "chrome-ide-trace": "^0.1.1",
     "@vue/eslint-config-typescript": "^9.1.0",
     "@vue/test-utils": "^2.0.0-0",
     "eslint": "catalog:",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import vue from '@vitejs/plugin-vue'
 import path from 'path'
 import { defineConfig } from 'vite'
 import pkg from './package.json'
+import { ideTraceVue } from 'chrome-ide-trace/vite'
 import { versionInfoUtil } from '../../common/utils/versionInfoUtil';
 import { VitePWA } from 'vite-plugin-pwa'
 import manifest from "./manifest.json"
@@ -12,6 +13,7 @@ import manifest from "./manifest.json"
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
+    ideTraceVue(),
     vue(),
     legacy(),
     VitePWA({


### PR DESCRIPTION
## Summary\n\nAdds IDE Trace plugin wiring to this app's Vite config and package config for Chrome DevTools integration from IDE Trace browser extension.\n\n## Files\n- package.json: add chrome-ide-trace devDependency\n- vite.config.{ts,js}: add ideTraceVue import and plugin entry