### PR TITLE
[codex] Standardize Order Routing favicon path

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <meta name="format-detection" content="telephone=no" />
     <meta name="msapplication-tap-highlight" content="no" />
 
-    <link rel="shortcut icon" type="image/png" href="/img/icons/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="%BASE_URL%img/icons/favicon-32x32.png" />
 
     <!-- add to homescreen for ios -->
     <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <meta name="format-detection" content="telephone=no" />
     <meta name="msapplication-tap-highlight" content="no" />
 
-    <link rel="shortcut icon" type="image/png" href="/assets/icon/favicon.png" />
+    <link rel="shortcut icon" type="image/png" href="/img/icons/favicon-32x32.png" />
 
     <!-- add to homescreen for ios -->
     <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,7 @@
     <meta name="format-detection" content="telephone=no" />
     <meta name="msapplication-tap-highlight" content="no" />
 
-    <link rel="shortcut icon" type="image/png" href="<%= BASE_URL %>img/icons/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="<%= BASE_URL %>img/icons/favicon-32x32.png" />
 
     <!-- add to homescreen for ios -->
     <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,7 @@
     <meta name="format-detection" content="telephone=no" />
     <meta name="msapplication-tap-highlight" content="no" />
 
-    <link rel="shortcut icon" type="image/png" href="<%= BASE_URL %>assets/icon/favicon.png" />
+    <link rel="shortcut icon" type="image/png" href="<%= BASE_URL %>img/icons/favicon-32x32.png" />
 
     <!-- add to homescreen for ios -->
     <meta name="apple-mobile-web-app-capable" content="yes" />


### PR DESCRIPTION
## Business summary
Standardizes the Order Routing app favicon path so browser tab icons use the shared `public/img/icons` export set from the design system. This makes future Figma icon exports apply consistently without separately maintaining the legacy `public/assets/icon/favicon.png` path.

Closes #356

## What changed
- Updated the active Vite `index.html` favicon link to `/img/icons/favicon-32x32.png`.
- Updated the legacy `public/index.html` template to use `<%= BASE_URL %>img/icons/favicon-32x32.png`.

## Validation
- Confirmed `public/img/icons/favicon-32x32.png` exists and is a 32x32 PNG.
- Ran `git diff --check`.
