### PR TITLE
Fix the search filtering issue

### DIFF
--- a/src/components/AddProductFiltersModal.vue
+++ b/src/components/AddProductFiltersModal.vue
@@ -109,7 +109,6 @@ async function search() {
 
   if(queryString.value.trim()) {
     isLoading.value = true;
-    await productStore.fetchProductFilters({ facetToSelect: props.facetToSelect, searchfield: props.searchfield, queryString: queryString.value.trim() })
     filteredOptions.value = productStore.getFacetOptions(props.searchfield).filter((option: any) => option.label.toLowerCase().includes(queryString.value.trim().toLowerCase()))
     isLoading.value = false;
   } else {

--- a/src/components/AddProductFiltersModal.vue
+++ b/src/components/AddProductFiltersModal.vue
@@ -104,15 +104,13 @@ function closeModal() {
   modalController.dismiss({ dismissed: true });
 }
 
-async function search() {
-  filteredOptions.value = []
+function search() {
+  const searchTerm = queryString.value.trim().toLowerCase();
 
-  if(queryString.value.trim()) {
-    isLoading.value = true;
-    filteredOptions.value = productStore.getFacetOptions(props.searchfield).filter((option: any) => option.label.toLowerCase().includes(queryString.value.trim().toLowerCase()))
-    isLoading.value = false;
+  if(searchTerm) {
+    filteredOptions.value = facetOptions.value.filter((option: any) => option.label.toLowerCase().includes(searchTerm))
   } else {
-    filteredOptions.value = JSON.parse(JSON.stringify(productStore.getFacetOptions(props.searchfield)))
+    filteredOptions.value = JSON.parse(JSON.stringify(facetOptions.value))
   }
 }
 

--- a/tests/addProductFiltersModal.test.ts
+++ b/tests/addProductFiltersModal.test.ts
@@ -1,0 +1,88 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { defineComponent, nextTick } from "vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("AddProductFiltersModal", () => {
+  const fetchProductFilters = vi.fn();
+  const facetOptions = [
+    { id: "Size/L", label: "Size/L", value: "Size/L" },
+    { id: "Size/XL", label: "Size/XL", value: "Size/XL" },
+    { id: "Color/Blue", label: "Color/Blue", value: "Color/Blue" },
+  ];
+
+  beforeEach(() => {
+    vi.resetModules();
+    fetchProductFilters.mockReset();
+    fetchProductFilters.mockResolvedValue(undefined);
+
+    vi.doMock("@common", () => ({
+      translate: (label: string, params?: { label?: string }) => params?.label ? `${label} ${params.label}` : label,
+    }));
+    vi.doMock("@/store/atpProductStore", () => ({
+      useAtpProductStore: () => ({
+        fetchProductFilters,
+        getAppliedFilters: {
+          included: { tags: [], productFeatures: [] },
+          excluded: { tags: [], productFeatures: [] },
+        },
+        getFacetOptions: () => facetOptions,
+        updateAppliedFilters: vi.fn(),
+      }),
+    }));
+    vi.doMock("@ionic/vue", () => ({
+      IonButton: defineComponent({ name: "IonButton", template: "<button><slot /></button>" }),
+      IonButtons: defineComponent({ name: "IonButtons", template: "<div><slot /></div>" }),
+      IonCheckbox: defineComponent({ name: "IonCheckbox", template: "<label><slot /></label>" }),
+      IonChip: defineComponent({ name: "IonChip", template: "<span><slot /></span>" }),
+      IonContent: defineComponent({ name: "IonContent", template: "<main><slot /></main>" }),
+      IonFab: defineComponent({ name: "IonFab", template: "<div><slot /></div>" }),
+      IonFabButton: defineComponent({ name: "IonFabButton", template: "<button><slot /></button>" }),
+      IonHeader: defineComponent({ name: "IonHeader", template: "<header><slot /></header>" }),
+      IonIcon: defineComponent({ name: "IonIcon", template: "<span />" }),
+      IonItem: defineComponent({ name: "IonItem", template: "<div><slot /></div>" }),
+      IonLabel: defineComponent({ name: "IonLabel", template: "<span><slot /></span>" }),
+      IonList: defineComponent({ name: "IonList", template: "<div><slot /></div>" }),
+      IonNote: defineComponent({ name: "IonNote", template: "<span><slot /></span>" }),
+      IonRow: defineComponent({ name: "IonRow", template: "<div><slot /></div>" }),
+      IonSearchbar: defineComponent({
+        name: "IonSearchbar",
+        props: ["modelValue"],
+        emits: ["keyup", "update:modelValue"],
+        template: `<input :value="modelValue" @input="$emit('update:modelValue', $event.target.value)" @keyup="$emit('keyup', $event)" />`,
+      }),
+      IonSpinner: defineComponent({ name: "IonSpinner", template: "<span />" }),
+      IonTitle: defineComponent({ name: "IonTitle", template: "<h1><slot /></h1>" }),
+      IonToolbar: defineComponent({ name: "IonToolbar", template: "<div><slot /></div>" }),
+      modalController: { dismiss: vi.fn() },
+    }));
+  });
+
+  it("filters loaded feature options without refetching from Solr", async () => {
+    const { default: AddProductFiltersModal } = await import("../src/components/AddProductFiltersModal.vue");
+    const wrapper = mount(AddProductFiltersModal, {
+      props: {
+        facetToSelect: "productFeaturesFacet",
+        label: "product features",
+        searchfield: "productFeatures",
+        type: "included",
+      },
+    });
+
+    await flushPromises();
+    await nextTick();
+
+    expect(fetchProductFilters).toHaveBeenCalledTimes(1);
+    expect(wrapper.text()).toContain("Size/L");
+    expect(wrapper.text()).toContain("Size/XL");
+
+    const searchbar = wrapper.find("input");
+    await searchbar.setValue("Size/XL");
+    await searchbar.trigger("keyup", { key: "Enter" });
+    await nextTick();
+
+    expect(fetchProductFilters).toHaveBeenCalledTimes(1);
+    expect(wrapper.text()).toContain("Size/XL");
+    expect(wrapper.text()).not.toContain("Size/L");
+    expect(wrapper.text()).not.toContain("Color/Blue");
+  });
+});


### PR DESCRIPTION
### Related Issues

#375, #388

### Summary
- Keep the Product Filters modal search on the already-loaded facet list instead of re-querying Solr on every typed search.
- Clean up the search handler by removing unused async/loading state from the local filtering path.
- Add a component regression test proving `Size/XL` remains visible after searching loaded product feature options and that `fetchProductFilters` is not called again during modal search.

### Why this layer
- The Jam for #375 shows the initial unfiltered `productFeaturesFacet` response includes `Size/XL`, but the subsequent filtered backend query for `term=Size/XL&q=Size/XL` returns an empty response.
- The modal already has the full facet option list loaded for selection, so the user-facing modal search should filter that loaded list consistently for tags and product features instead of depending on a second Solr query path.

### Verification
- Reviewed Jam #375: https://jam.dev/c/e2db9f2e-dff1-4e0e-8911-a6056164d544
- `git diff --check`
- `npm run test:unit -- tests/addProductFiltersModal.test.ts --run`
- `npm run build`
