### PR TITLE
fix: update rule archiving error toast message

### DIFF
--- a/src/components/RuleItem.vue
+++ b/src/components/RuleItem.vue
@@ -337,7 +337,7 @@ async function archiveRule() {
             commonUtil.showToast(translate("Rule archived successfully."))
             alertController.dismiss()
           } catch(err: any) {
-            commonUtil.showToast(translate("Failed to update threhold."))
+            commonUtil.showToast(translate("Failed to archive rule."))
             logger.error(err);
           }
           emitter.emit("dismissLoader");


### PR DESCRIPTION
### Related Issues
#382

### Short Description and Why It's Useful
This PR resolves an issue where an incorrect and misspelled error message ("Failed to update threhold.") was displayed when a user encountered an API error while archiving a rule. 
Since the `RuleItem` component is shared across different sections (such as Safety Stock and Threshold), hardcoding "threshold" in the error catch block provided inaccurate context to the user.

**Changes Made**
* Updated the `catch` block within the `archiveRule()` method in `src/components/RuleItem.vue`.
* Replaced the hardcoded error message with a context-agnostic string: `"Failed to archive rule."`.

**Steps to Test**
1. Navigate to the Safety Stock or Threshold page.
2. Open Chrome DevTools and set the Network throttling to "Offline".
3. Expand any existing rule card and click the Archive icon.
4. Confirm the action and verify that the toast notification correctly displays "Failed to archive rule." instead of "Failed to update threhold."

### Screenshots of Visual Changes before/after 
<img width="1300" height="736" alt="Failed_to_archive_Threshold" src="https://github.com/user-attachments/assets/52e986d4-83cf-4166-bd43-d3f86520e978" />
<img width="1300" height="736" alt="Failed_to_archive_SafetyStock" src="https://github.com/user-attachments/assets/5446e83b-a37b-4317-a0f5-42523126be58" />

### Screenshots of Visual Changes after 
<img width="1300" height="736" alt="Fail_to_archive_rule" src="https://github.com/user-attachments/assets/b26fdc0c-d4c9-4487-9ad7-2c16d51adc64" />
<img width="1300" height="736" alt="Fail-toarchive_rule_2" src="https://github.com/user-attachments/assets/062d5c06-ee85-4078-8602-08b5648b8b34" />





### Contribution and Currently Important Rules Acceptance
- [x] I read and followed [contribution rules](https://github.com/hotwax/order-routing-rules#contribution-guideline)