### PR TITLE
Fix issue #386: Sync product stores between settings and global scope

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -223,7 +223,8 @@ async function setProductStore(event: SelectCustomEvent) {
           {
             text: translate("Yes"),
             handler: async () => {
-              await atpProductStore.setCurrentProductStore({ productStoreId: event.detail.value });
+              const store = productStores.value.find((store: any) => store.productStoreId === event.detail.value);
+              atpProductStore.setCurrentProductStore(store || { productStoreId: event.detail.value });
               productStore().setEcomStore({ productStoreId: event.detail.value });
               emitter.emit("productStoreOrConfigChanged");
             }
@@ -232,7 +233,8 @@ async function setProductStore(event: SelectCustomEvent) {
       });
       alert.present();
     } else {
-      atpProductStore.setCurrentProductStore({ productStoreId: event.detail.value });
+      const store = productStores.value.find((store: any) => store.productStoreId === event.detail.value);
+      atpProductStore.setCurrentProductStore(store || { productStoreId: event.detail.value });
       productStore().setEcomStore({ productStoreId: event.detail.value });
       emitter.emit("productStoreOrConfigChanged");
     }

--- a/src/App.vue
+++ b/src/App.vue
@@ -131,6 +131,7 @@ import { commonUtil, emitter, translate } from "@common";
 import { useAuth } from "@common/composables/useAuth";
 import { useUserStore } from "@/store/userStore";
 import { useAtpProductStore } from "@/store/atpProductStore";
+import { productStore } from "@/store/productStore";
 import { isFeatureEnabled } from "@/utils/simConfig";
 import router from "@/router";
 
@@ -223,6 +224,7 @@ async function setProductStore(event: SelectCustomEvent) {
             text: translate("Yes"),
             handler: async () => {
               await atpProductStore.setCurrentProductStore({ productStoreId: event.detail.value });
+              productStore().setEcomStore({ productStoreId: event.detail.value });
               emitter.emit("productStoreOrConfigChanged");
             }
           }
@@ -231,6 +233,7 @@ async function setProductStore(event: SelectCustomEvent) {
       alert.present();
     } else {
       atpProductStore.setCurrentProductStore({ productStoreId: event.detail.value });
+      productStore().setEcomStore({ productStoreId: event.detail.value });
       emitter.emit("productStoreOrConfigChanged");
     }
   }

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -225,9 +225,9 @@ function setEComStore(event: CustomEvent) {
     productStore().setEcomStore({
       "productStoreId": event.detail.value
     })
-    useAtpProductStore().setCurrentProductStore({
-      "productStoreId": event.detail.value
-    })
+    const atpProductStore = useAtpProductStore();
+    const store = atpProductStore.productStores.find((store: any) => store.productStoreId === event.detail.value);
+    atpProductStore.setCurrentProductStore(store || { productStoreId: event.detail.value });
     emitter.emit("productStoreOrConfigChanged");
   }
 }

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -175,10 +175,11 @@ import { computed, onMounted, ref } from "vue";
 import { useUserStore } from "@/store/userStore";
 import { useCircuitStore } from "@/store/circuit";
 import { productStore } from "@/store/productStore";
+import { useAtpProductStore } from "@/store/atpProductStore";
 import TimeZoneModal from "@/components/TimezoneModal.vue";
 import Image from "@/components/Image.vue"
 import { openOutline } from "ionicons/icons"
-import { translate, commonUtil, cookieHelper } from "@common";
+import { translate, commonUtil, cookieHelper, emitter } from "@common";
 import { useAuth } from "@common/composables/useAuth";
 import DxpAppVersionInfo from "@/components/DxpAppVersionInfo.vue";
 
@@ -224,6 +225,10 @@ function setEComStore(event: CustomEvent) {
     productStore().setEcomStore({
       "productStoreId": event.detail.value
     })
+    useAtpProductStore().setCurrentProductStore({
+      "productStoreId": event.detail.value
+    })
+    emitter.emit("productStoreOrConfigChanged");
   }
 }
 


### PR DESCRIPTION
Fixes #386

Synchronizes the global product store state by ensuring `atpProductStore` and `productStoreOrConfigChanged` are updated when the eCommerce store is changed in the Settings page.