### PR TITLE
Fixed: sync product store between settings and global scope

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -131,6 +131,7 @@ import { commonUtil, emitter, translate } from "@common";
 import { useAuth } from "@common/composables/useAuth";
 import { useUserStore } from "@/store/userStore";
 import { useAtpProductStore } from "@/store/atpProductStore";
+import { productStore } from "@/store/productStore";
 import { isFeatureEnabled } from "@/utils/simConfig";
 import router from "@/router";
 
@@ -222,7 +223,9 @@ async function setProductStore(event: SelectCustomEvent) {
           {
             text: translate("Yes"),
             handler: async () => {
-              await atpProductStore.setCurrentProductStore({ productStoreId: event.detail.value });
+              const store = productStores.value.find((s: any) => s.productStoreId === event.detail.value);
+              atpProductStore.setCurrentProductStore(store || { productStoreId: event.detail.value });
+              productStore().setEcomStore({ productStoreId: event.detail.value });
               emitter.emit("productStoreOrConfigChanged");
             }
           }
@@ -230,7 +233,9 @@ async function setProductStore(event: SelectCustomEvent) {
       });
       alert.present();
     } else {
-      atpProductStore.setCurrentProductStore({ productStoreId: event.detail.value });
+      const store = productStores.value.find((s: any) => s.productStoreId === event.detail.value);
+      atpProductStore.setCurrentProductStore(store || { productStoreId: event.detail.value });
+      productStore().setEcomStore({ productStoreId: event.detail.value });
       emitter.emit("productStoreOrConfigChanged");
     }
   }

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -175,10 +175,11 @@ import { computed, onMounted, ref } from "vue";
 import { useUserStore } from "@/store/userStore";
 import { useCircuitStore } from "@/store/circuit";
 import { productStore } from "@/store/productStore";
+import { useAtpProductStore } from "@/store/atpProductStore";
 import TimeZoneModal from "@/components/TimezoneModal.vue";
 import Image from "@/components/Image.vue"
 import { openOutline } from "ionicons/icons"
-import { translate, commonUtil, cookieHelper } from "@common";
+import { translate, commonUtil, cookieHelper, emitter } from "@common";
 import { useAuth } from "@common/composables/useAuth";
 import DxpAppVersionInfo from "@/components/DxpAppVersionInfo.vue";
 
@@ -224,6 +225,10 @@ function setEComStore(event: CustomEvent) {
     productStore().setEcomStore({
       "productStoreId": event.detail.value
     })
+    const atpProductStore = useAtpProductStore();
+    const store = atpProductStore.productStores.find((s: any) => s.productStoreId === event.detail.value);
+    atpProductStore.setCurrentProductStore(store || { productStoreId: event.detail.value });
+    emitter.emit("productStoreOrConfigChanged");
   }
 }
 


### PR DESCRIPTION
Resolves #386

## Problem
The Order Routing app maintains two separate product store states:
- `productStore` (used by Settings and Routing views)
- `atpProductStore` (used by the global sidebar and Sourcing/ATP views)

Changing the Product Store in Settings only updated `productStore`, while changing it in the sidebar only updated `atpProductStore`. Because these states were isolated, the two selectors fell out of sync.

## Changes
- **Settings.vue:** When a store is selected, now updates both `productStore` and `atpProductStore`, and emits `productStoreOrConfigChanged`.
- **App.vue:** When a store is selected via the sidebar, now also updates `productStore` (EComStore) in addition to `atpProductStore`.

## Testing
1. Change the store in Settings → sidebar updates instantly.
2. Change the store in the sidebar → Settings reflects the new store.
