### PR TITLE
Fix inventory row checkbox selection state

### DIFF
--- a/src/views/Inventory.vue
+++ b/src/views/Inventory.vue
@@ -33,7 +33,7 @@
           </ion-item>
           <div class="list-item" v-for="product in products" :key="product.productId" @click="viewInventoryDetail(product.productId)">
             <ion-item>
-              <ion-checkbox :checked="product.isChecked" slot="start" @click.stop @ionChange="product.isChecked = $event.detail.checked"></ion-checkbox>
+              <ion-checkbox v-model="product.isChecked" slot="start" @click.stop></ion-checkbox>
               <ion-thumbnail data-testid="assigned-detail-product-thumbnail">
                 <DxpShopifyImg :src="productById(product.productId).mainImageUrl" data-testid="assigned-detail-product-img"/>
               </ion-thumbnail>

--- a/tests/inventorySelection.test.ts
+++ b/tests/inventorySelection.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe("Inventory product selection", () => {
+  it("binds row checkboxes directly to the product selection state", () => {
+    const inventoryView = readFileSync(resolve(__dirname, "../src/views/Inventory.vue"), "utf8");
+
+    expect(inventoryView).toContain('<ion-checkbox v-model="product.isChecked" slot="start" @click.stop></ion-checkbox>');
+    expect(inventoryView).not.toContain('@ionChange="product.isChecked');
+  });
+});

--- a/tests/inventorySelection.test.ts
+++ b/tests/inventorySelection.test.ts
@@ -1,15 +1,104 @@
-import { describe, expect, it } from "vitest";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, resolve } from "node:path";
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
+import { mount } from "@vue/test-utils";
+import { defineComponent, nextTick, ref } from "vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("Inventory product selection", () => {
-  it("binds row checkboxes directly to the product selection state", () => {
-    const inventoryView = readFileSync(resolve(__dirname, "../src/views/Inventory.vue"), "utf8");
+  const products = ref<any[]>([]);
+  const modalCreate = vi.fn();
 
-    expect(inventoryView).toContain('<ion-checkbox v-model="product.isChecked" slot="start" @click.stop></ion-checkbox>');
-    expect(inventoryView).not.toContain('@ionChange="product.isChecked');
+  beforeEach(() => {
+    vi.resetModules();
+    products.value = [
+      { productId: "M102977", parentProductName: "Gift card", isChecked: true },
+      { productId: "M101833", parentProductName: "Teton Pullover Hoodie", isChecked: false },
+    ];
+    modalCreate.mockReset();
+    modalCreate.mockResolvedValue({
+      onDidDismiss: vi.fn(() => Promise.resolve({ data: { updated: false } })),
+      present: vi.fn(() => Promise.resolve()),
+    });
+
+    vi.doMock("@common", () => ({
+      DxpShopifyImg: defineComponent({ name: "DxpShopifyImg", template: "<img />" }),
+      translate: (label: string) => label,
+    }));
+    vi.doMock("../src/router", () => ({
+      default: { push: vi.fn() },
+    }));
+    vi.doMock("../src/router/index", () => ({
+      default: { push: vi.fn() },
+    }));
+    vi.doMock("@/components/ProductFacilityConfigEditModal.vue", () => ({
+      default: defineComponent({ name: "ProductFacilityConfigEditModal", template: "<div />" }),
+    }));
+    vi.doMock("@/components/ProductInventoryEdit.vue", () => ({
+      default: defineComponent({ name: "ProductInventoryEdit", template: "<div />" }),
+    }));
+    vi.doMock("@/composables/useProductFacility", () => ({
+      useProductFacility: () => ({
+        fetchProductFacility: vi.fn(() => Promise.resolve(products.value.length)),
+        productFacility: products,
+      }),
+    }));
+    vi.doMock("@/store/product", () => ({
+      productStore: () => ({
+        getProductById: () => ({ mainImageUrl: "" }),
+      }),
+    }));
+    vi.doMock("@/store/productStore", () => ({
+      productStore: () => ({
+        fetchProductStoreFacilities: vi.fn(() => Promise.resolve()),
+        productStoreFacilities: [{ facilityId: "BROOKLYN", facilityName: "Brooklyn" }],
+        selectedInventoryFacilityId: "BROOKLYN",
+        setSelectedInventoryFacilityId: vi.fn(),
+      }),
+    }));
+    vi.doMock("@ionic/vue", () => ({
+      IonButton: defineComponent({ name: "IonButton", template: "<button><slot /></button>" }),
+      IonButtons: defineComponent({ name: "IonButtons", template: "<div><slot /></div>" }),
+      IonCheckbox: defineComponent({
+        name: "IonCheckbox",
+        props: ["checked", "indeterminate", "modelValue"],
+        emits: ["ionChange", "update:modelValue"],
+        template: "<button><slot /></button>",
+      }),
+      IonContent: defineComponent({ name: "IonContent", template: "<main><slot /></main>" }),
+      IonFooter: defineComponent({ name: "IonFooter", template: "<footer><slot /></footer>" }),
+      IonHeader: defineComponent({ name: "IonHeader", template: "<header><slot /></header>" }),
+      IonIcon: defineComponent({ name: "IonIcon", template: "<span />" }),
+      IonItem: defineComponent({ name: "IonItem", template: "<div><slot /></div>" }),
+      IonLabel: defineComponent({ name: "IonLabel", template: "<label><slot /></label>" }),
+      IonList: defineComponent({ name: "IonList", template: "<div><slot /></div>" }),
+      IonNote: defineComponent({ name: "IonNote", template: "<span><slot /></span>" }),
+      IonPage: defineComponent({ name: "IonPage", template: "<section><slot /></section>" }),
+      IonSearchbar: defineComponent({ name: "IonSearchbar", template: "<input />" }),
+      IonSelect: defineComponent({ name: "IonSelect", template: "<select><slot /></select>" }),
+      IonSelectOption: defineComponent({ name: "IonSelectOption", template: "<option><slot /></option>" }),
+      IonThumbnail: defineComponent({ name: "IonThumbnail", template: "<div><slot /></div>" }),
+      IonTitle: defineComponent({ name: "IonTitle", template: "<h1><slot /></h1>" }),
+      IonToolbar: defineComponent({ name: "IonToolbar", template: "<div><slot /></div>" }),
+      modalController: { create: modalCreate },
+      onIonViewDidEnter: vi.fn(),
+    }));
+  });
+
+  it("passes only currently checked products into the bulk inventory edit modal", async () => {
+    const { default: Inventory } = await import("../src/views/Inventory.vue");
+    const wrapper = mount(Inventory);
+
+    const rowCheckboxes = wrapper.findAllComponents({ name: "IonCheckbox" }).slice(1);
+    await rowCheckboxes[0].vm.$emit("update:modelValue", false);
+    await rowCheckboxes[1].vm.$emit("update:modelValue", true);
+    await nextTick();
+
+    const adjustInventoryButton = wrapper.findAllComponents({ name: "IonButton" }).find((button) => button.text() === "Adjust Inventory");
+    expect(adjustInventoryButton).toBeTruthy();
+    await adjustInventoryButton?.trigger("click");
+
+    expect(modalCreate).toHaveBeenCalledTimes(1);
+    const selectedProducts = modalCreate.mock.calls[0][0].componentProps.selectedProducts;
+
+    expect(selectedProducts).toHaveLength(1);
+    expect(selectedProducts[0].productId).toBe("M101833");
   });
 });


### PR DESCRIPTION
## Summary
- Prevent unchecked Inventory rows from being included in bulk inventory variance submissions.
- Switch the row checkbox to Ionic Vue's direct `v-model` binding for `product.isChecked`, so checked and unchecked UI state stays aligned with the products passed to the modal.
- Add a component-level regression test that mounts `Inventory.vue`, changes row checkbox state, opens the bulk inventory edit modal, and asserts only currently checked products are passed.

## Evidence
- Issue: https://github.com/hotwax/order-routing/issues/377
- Jam: https://jam.dev/c/b3e3f6a8-885b-4723-88fe-f010de2bd627
- Jam showed `M102977` unchecked visually but still present in the `recordVariance` payload along with `M101833`.

## Why this layer
- The backend accepted the submitted `recordVariance` payload with status 200 in Jam; the defect was the frontend selection state passed into `ProductInventoryEdit`.
- Ionic Vue 8.8 maps `v-model` on `IonCheckbox` to the checkbox value binding, which is the right component-level state binding here.

## Verification
- `git diff --check`
- `npm run test:unit -- tests/inventorySelection.test.ts --run`
- `npm run build`
- Reviewed the Jam video/network payload against `test-maarg`.
- Browser reached local `/inventory` against `test-maarg`; live product search returned a separate backend/search 400 even with `facilityId`, so this PR does not add a frontend workaround or fake app-side server behavior for that separate failure.

## Risk
- Low. The change is scoped to the row checkbox binding and the modal continues to receive `products.value.filter((product) => product.isChecked)`.

Closes #377
