### PR TITLE
Show all facility group types

### DIFF
--- a/src/views/FacilityGroups.vue
+++ b/src/views/FacilityGroups.vue
@@ -130,8 +130,7 @@ import ManageFacilityGroupFacilitiesModal from "@/components/ManageFacilityGroup
 const facilityGroupStore = useFacilityGroupStore();
 const productStore = useAtpProductStore();
 
-// This view manages brokering facility groups for the selected product store only.
-const BROKERING_GROUP_TYPE = "BROKERING_GROUP";
+const DEFAULT_GROUP_TYPE = "BROKERING_GROUP";
 
 const query = ref("");
 
@@ -169,7 +168,7 @@ async function load() {
     return;
   }
   try {
-    await facilityGroupStore.fetchGroups({ productStoreId, facilityGroupTypeId: BROKERING_GROUP_TYPE });
+    await facilityGroupStore.fetchGroups({ productStoreId });
   } catch (err) {
     logger.error("Failed to load facility groups", err);
   }
@@ -178,7 +177,7 @@ async function load() {
 async function openCreateModal() {
   const modal = await modalController.create({
     component: CreateUpdateFacilityGroupModal,
-    componentProps: { defaultTypeId: BROKERING_GROUP_TYPE }
+    componentProps: { defaultTypeId: DEFAULT_GROUP_TYPE }
   });
   modal.onDidDismiss().then((res: any) => {
     if (res?.data?.saved) load();

--- a/tests/facilityGroupsView.test.ts
+++ b/tests/facilityGroupsView.test.ts
@@ -1,0 +1,92 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { defineComponent, nextTick } from "vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("FacilityGroups view", () => {
+  const fetchGroups = vi.fn();
+  const groups = [
+    {
+      facilityGroupId: "OnlineFacilityGroup",
+      facilityGroupName: "Online Facility Group",
+      facilityGroupTypeId: "BROKERING_GROUP",
+    },
+    {
+      facilityGroupId: "FULFILLMENT_TEST",
+      facilityGroupName: "Fulfillment Test",
+      facilityGroupTypeId: "FULFILLMENT",
+    },
+  ];
+
+  beforeEach(() => {
+    vi.resetModules();
+    fetchGroups.mockReset();
+    fetchGroups.mockResolvedValue(undefined);
+
+    vi.doMock("@common", () => ({
+      commonUtil: { showToast: vi.fn() },
+      logger: { error: vi.fn() },
+      translate: (label: string) => label,
+    }));
+    vi.doMock("@/components/CreateUpdateFacilityGroupModal.vue", () => ({
+      default: defineComponent({ name: "CreateUpdateFacilityGroupModal", template: "<div />" }),
+    }));
+    vi.doMock("@/components/EmptyState.vue", () => ({
+      default: defineComponent({ name: "EmptyState", template: "<div><slot /><slot name='actions' /></div>" }),
+    }));
+    vi.doMock("@/components/ManageFacilityGroupFacilitiesModal.vue", () => ({
+      default: defineComponent({ name: "ManageFacilityGroupFacilitiesModal", template: "<div />" }),
+    }));
+    vi.doMock("@/store/atpProductStore", () => ({
+      useAtpProductStore: () => ({
+        getCurrentProductStore: { productStoreId: "STORE" },
+      }),
+    }));
+    vi.doMock("@/store/facilityGroupStore", () => ({
+      useFacilityGroupStore: () => ({
+        $patch: vi.fn(),
+        archiveGroup: vi.fn(),
+        fetchGroups,
+        getGroupFacilities: () => [],
+        getGroupTypes: [
+          { facilityGroupTypeId: "BROKERING_GROUP", description: "Brokering" },
+          { facilityGroupTypeId: "FULFILLMENT", description: "Fulfillment" },
+        ],
+        getGroups: groups,
+      }),
+    }));
+    vi.doMock("@ionic/vue", () => ({
+      alertController: { create: vi.fn() },
+      IonButton: defineComponent({ name: "IonButton", template: "<button><slot /></button>" }),
+      IonButtons: defineComponent({ name: "IonButtons", template: "<div><slot /></div>" }),
+      IonCard: defineComponent({ name: "IonCard", template: "<article><slot /></article>" }),
+      IonCardHeader: defineComponent({ name: "IonCardHeader", template: "<header><slot /></header>" }),
+      IonCardSubtitle: defineComponent({ name: "IonCardSubtitle", template: "<p><slot /></p>" }),
+      IonCardTitle: defineComponent({ name: "IonCardTitle", template: "<h2><slot /></h2>" }),
+      IonChip: defineComponent({ name: "IonChip", template: "<span><slot /></span>" }),
+      IonContent: defineComponent({ name: "IonContent", template: "<main><slot /></main>" }),
+      IonHeader: defineComponent({ name: "IonHeader", template: "<header><slot /></header>" }),
+      IonIcon: defineComponent({ name: "IonIcon", template: "<span />" }),
+      IonItem: defineComponent({ name: "IonItem", template: "<div><slot /></div>" }),
+      IonLabel: defineComponent({ name: "IonLabel", template: "<span><slot /></span>" }),
+      IonMenuButton: defineComponent({ name: "IonMenuButton", template: "<button />" }),
+      IonPage: defineComponent({ name: "IonPage", template: "<section><slot /></section>" }),
+      IonSearchbar: defineComponent({ name: "IonSearchbar", template: "<input />" }),
+      IonTitle: defineComponent({ name: "IonTitle", template: "<h1><slot /></h1>" }),
+      IonToolbar: defineComponent({ name: "IonToolbar", template: "<div><slot /></div>" }),
+      modalController: { create: vi.fn() },
+    }));
+  });
+
+  it("loads and renders all product-store facility group types", async () => {
+    const { default: FacilityGroups } = await import("../src/views/FacilityGroups.vue");
+
+    const wrapper = mount(FacilityGroups);
+    await flushPromises();
+    await nextTick();
+
+    expect(fetchGroups).toHaveBeenCalledWith({ productStoreId: "STORE" });
+    expect(fetchGroups).not.toHaveBeenCalledWith(expect.objectContaining({ facilityGroupTypeId: "BROKERING_GROUP" }));
+    expect(wrapper.text()).toContain("Online Facility Group");
+    expect(wrapper.text()).toContain("Fulfillment Test");
+  });
+});


### PR DESCRIPTION
## Summary
- Remove the Brokering-only request filter from the Facility groups page load.
- Keep the New group modal defaulting to Brokering, but allow the page list to render every group type associated with the selected product store.
- Add a mounted view regression test proving the page fetches product-store groups without `facilityGroupTypeId` and renders both Brokering and Fulfillment groups.

## Evidence
- Issue: https://github.com/hotwax/order-routing/issues/376
- Jam: https://jam.dev/c/75c2960f-5f2c-4c8c-8d7b-9da5ccebcd1e
- Jam network shows the Facility groups page calling `admin/productStores/STORE/facilityGroups?pageSize=200&productStoreId=STORE&facilityGroupTypeId=BROKERING_GROUP`, which can only return Brokering groups even when other product-store groups exist.

## Why this layer
- This is a frontend request-shaping bug: the page applies `facilityGroupTypeId=BROKERING_GROUP` while the expected page behavior is to show all product-store facility group types.
- No backend workaround is needed; the existing endpoint already supports an unfiltered product-store group request.

## Verification
- `git diff --check`
- `npm run test:unit -- tests/facilityGroupsView.test.ts --run`
- `npm run build`
- Reviewed the Jam video/network payload against `test-maarg`.

## Notes
- Direct curl verification against `test-maarg` could not be completed because the local registry credential currently returns `400` on `admin/login`; no password or token was printed. The Jam network evidence still proves the app-side failing request shape on `test-maarg`.

Closes #376
