### PR TITLE
Fix dashboard facility group scope

### DIFF
--- a/src/store/dashboardStore.ts
+++ b/src/store/dashboardStore.ts
@@ -17,6 +17,8 @@ const SOURCING = [
   { key: "shipping", label: "Shipping", route: "/shipping", groupTypes: ["RG_SHIPPING_FACILITY", "RG_SHIPPING_CHANNEL"], metric: "shipping" }
 ];
 
+const BROKERING_GROUP_TYPE = "BROKERING_GROUP";
+
 function isTruthyFlag(value: any) {
   return value === true || value === "Y" || value === "y";
 }
@@ -341,9 +343,14 @@ export const useDashboardStore = defineStore("dashboard", {
     },
     async loadFoundations() {
       const foundations = { facilityGroups: 0, facilityGroupsByType: {} as Record<string, number>, channels: 0 };
+      const productStoreId = useAtpProductStore().currentProductStore?.productStoreId;
+      if (!productStoreId) {
+        this.foundations = foundations;
+        return;
+      }
       try {
         const facilityGroupStore = useFacilityGroupStore();
-        await facilityGroupStore.fetchGroups();
+        await facilityGroupStore.fetchGroups({ productStoreId, facilityGroupTypeId: BROKERING_GROUP_TYPE });
         const facilityGroups = facilityGroupStore.getGroups || [];
         foundations.facilityGroups = facilityGroups.length;
         for (const facilityGroup of facilityGroups) {

--- a/tests/dashboardStore.test.ts
+++ b/tests/dashboardStore.test.ts
@@ -1,0 +1,78 @@
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useAtpProductStore } from "@/store/atpProductStore";
+import { useDashboardStore } from "@/store/dashboardStore";
+import { api } from "@common";
+
+vi.mock("@common", () => ({
+  api: vi.fn(),
+  commonUtil: {
+    hasError: vi.fn((response: any) => Boolean(response?.error || response?.data?._ERROR_MESSAGE_))
+  },
+  logger: {
+    error: vi.fn()
+  }
+}));
+
+vi.mock("@/store/userStore", () => ({
+  useUserStore: vi.fn(() => ({}))
+}));
+
+const mockedApi = vi.mocked(api);
+
+describe("dashboardStore.loadFoundations", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockedApi.mockReset();
+  });
+
+  it("loads facility groups using the same selected-store brokering scope as the Facility groups page", async () => {
+    useAtpProductStore().$patch({ currentProductStore: { productStoreId: "STORE" } });
+    mockedApi.mockImplementation(async (request: any) => {
+      if (request.url === "admin/productStores/STORE/facilityGroups" && request.params?.facilityGroupTypeId === "BROKERING_GROUP") {
+        return {
+          data: [
+            { facilityGroupId: "BROKERING_1", facilityGroupTypeId: "BROKERING_GROUP" },
+            { facilityGroupId: "BROKERING_2", facilityGroupTypeId: "BROKERING_GROUP" }
+          ]
+        };
+      }
+      if (request.url === "admin/productStores/STORE/facilityGroups" && request.params?.facilityGroupTypeId === "CHANNEL_FAC_GROUP") {
+        return { data: [{ facilityGroupId: "CHANNEL_1" }] };
+      }
+      if (request.url === "/oms/groupFacilities") {
+        return { data: [] };
+      }
+      return { data: [] };
+    });
+
+    await useDashboardStore().loadFoundations();
+
+    expect(mockedApi).toHaveBeenCalledWith(expect.objectContaining({
+      url: "admin/productStores/STORE/facilityGroups",
+      method: "GET",
+      params: expect.objectContaining({
+        productStoreId: "STORE",
+        facilityGroupTypeId: "BROKERING_GROUP",
+        pageSize: 200
+      })
+    }));
+    expect(mockedApi).not.toHaveBeenCalledWith(expect.objectContaining({ url: "/oms/facilityGroups" }));
+    expect(useDashboardStore().getFoundations).toEqual({
+      facilityGroups: 2,
+      facilityGroupsByType: { BROKERING_GROUP: 2 },
+      channels: 1
+    });
+  });
+
+  it("leaves foundation metrics empty until a product store is selected", async () => {
+    await useDashboardStore().loadFoundations();
+
+    expect(mockedApi).not.toHaveBeenCalled();
+    expect(useDashboardStore().getFoundations).toEqual({
+      facilityGroups: 0,
+      facilityGroupsByType: {},
+      channels: 0
+    });
+  });
+});


### PR DESCRIPTION
## Business summary
The dashboard Facility groups tile was showing a system-wide count that could not be opened from the selected product store's Facility groups page. This made Launch QA think 12 groups existed for the current store when the page correctly loaded the selected-store Brokering group scope. The fix aligns the dashboard count with the page it links to so the dashboard does not advertise inaccessible groups.

## Code summary
- Scope `dashboardStore.loadFoundations()` to the current product store and `BROKERING_GROUP`, matching `FacilityGroups.vue`.
- Return zero foundation metrics when there is no selected product store instead of falling back to a system-wide group count.
- Add a focused Pinia/Vitest regression test asserting the dashboard does not call `/oms/facilityGroups` for this card.

## Evidence
- Issue: https://github.com/hotwax/order-routing/issues/369
- Jam: https://jam.dev/c/4a8863c2-1616-4577-88e0-2f798ecf12c5
- Jam network showed the mismatch on `test-maarg`: `/oms/facilityGroups?pageSize=200` returned `x-total-count: 12`, while `/admin/productStores/CODEX219/facilityGroups?...facilityGroupTypeId=BROKERING_GROUP` returned `x-total-count: 0` in the reported session.
- Local browser verification against `test-maarg` after the fix showed dashboard Facility groups `1` and `/facility-groups` showing the same one Brokering group.
- Screenshot evidence:

  ![Dashboard Facility groups count matching the selected store](https://github.com/hotwax/order-routing/releases/download/codex-order-routing-screenshots-20260620/issue-369-dashboard.png)

  ![Facility groups page showing the same selected-store Brokering group](https://github.com/hotwax/order-routing/releases/download/codex-order-routing-screenshots-20260620/issue-369-facility-groups.png)

## Why this layer
This is a frontend request-shaping bug. The backend returned successful 200 responses for both endpoints; the issue was that the dashboard requested the system-wide facility-group list while the linked page requested selected-store Brokering groups. No local or server-side workaround was used.

## Verification
- `git diff --check`
- `npm run test:unit -- tests/dashboardStore.test.ts --run`
- `npm run build`
- Browser run on `http://127.0.0.1:8129` authenticated against `test-maarg` and confirmed the dashboard/page counts match.

Closes #369
