### PR TITLE
Fix facility group archive persistence

### DIFF
--- a/src/store/facilityGroupStore.ts
+++ b/src/store/facilityGroupStore.ts
@@ -159,10 +159,14 @@ export const useFacilityGroupStore = defineStore("facilityGroup", {
     },
     async archiveGroup(facilityGroupId: string) {
       const thruDate = Date.now();
+      const productStoreId = useAtpProductStore().currentProductStore?.productStoreId;
+      const group = this.groups.find((g: any) => g.facilityGroupId === facilityGroupId);
+      if (!productStoreId) throw new Error("No product store selected");
+      if (group?.fromDate == null) throw new Error("No active product store association found for facility group.");
       const resp = await api({
-        url: `admin/facilityGroups/${facilityGroupId}`,
-        method: "PUT",
-        params: { facilityGroupId, thruDate }
+        url: `admin/productStores/${productStoreId}/facilityGroups/${facilityGroupId}/association`,
+        method: "POST",
+        data: { productStoreId, facilityGroupId, fromDate: group.fromDate, thruDate }
       }) as any;
       if (commonUtil.hasError(resp)) throw resp.data;
       this.groups = this.groups.filter((g: any) => g.facilityGroupId !== facilityGroupId);

--- a/src/store/facilityGroupStore.ts
+++ b/src/store/facilityGroupStore.ts
@@ -162,7 +162,8 @@ export const useFacilityGroupStore = defineStore("facilityGroup", {
       const productStoreId = useAtpProductStore().currentProductStore?.productStoreId;
       const group = this.groups.find((g: any) => g.facilityGroupId === facilityGroupId);
       if (!productStoreId) throw new Error("No product store selected");
-      if (group?.fromDate == null) throw new Error("No active product store association found for facility group.");
+      if (!group) throw new Error("Facility group not found in current product store.");
+      if (group.fromDate == null) throw new Error("No active product store association found for facility group.");
       const resp = await api({
         url: `admin/productStores/${productStoreId}/facilityGroups/${facilityGroupId}/association`,
         method: "POST",

--- a/tests/facilityGroupStore.test.ts
+++ b/tests/facilityGroupStore.test.ts
@@ -74,4 +74,13 @@ describe("facilityGroupStore.archiveGroup", () => {
     expect(mockedApi).not.toHaveBeenCalled();
     expect(facilityGroupStore.getGroups).toHaveLength(1);
   });
+
+  it("reports when the group is not loaded in local product store state", async () => {
+    useAtpProductStore().$patch({ currentProductStore: { productStoreId: "STORE" } });
+    const facilityGroupStore = useFacilityGroupStore();
+
+    await expect(facilityGroupStore.archiveGroup("FG1")).rejects.toThrow("Facility group not found in current product store.");
+
+    expect(mockedApi).not.toHaveBeenCalled();
+  });
 });

--- a/tests/facilityGroupStore.test.ts
+++ b/tests/facilityGroupStore.test.ts
@@ -1,0 +1,77 @@
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useAtpProductStore } from "@/store/atpProductStore";
+import { useFacilityGroupStore } from "@/store/facilityGroupStore";
+import { api } from "@common";
+
+vi.mock("@common", () => ({
+  api: vi.fn(),
+  commonUtil: {
+    hasError: vi.fn((response: any) => Boolean(response?.error || response?.data?._ERROR_MESSAGE_))
+  },
+  logger: {
+    error: vi.fn()
+  }
+}));
+
+vi.mock("@/store/userStore", () => ({
+  useUserStore: vi.fn(() => ({}))
+}));
+
+const mockedApi = vi.mocked(api);
+
+describe("facilityGroupStore.archiveGroup", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockedApi.mockReset();
+    vi.spyOn(Date, "now").mockReturnValue(1781896000000);
+  });
+
+  it("expires the selected product store association for the loaded facility group", async () => {
+    useAtpProductStore().$patch({ currentProductStore: { productStoreId: "STORE" } });
+    const facilityGroupStore = useFacilityGroupStore();
+    facilityGroupStore.$patch({
+      groups: [
+        {
+          productStoreId: "STORE",
+          facilityGroupId: "FG1",
+          fromDate: 1781895000000,
+          facilityGroupTypeId: "BROKERING_GROUP"
+        }
+      ],
+      facilitiesByGroup: {
+        FG1: [{ facilityId: "FACILITY" }]
+      }
+    });
+    mockedApi.mockResolvedValue({ data: {} });
+
+    await facilityGroupStore.archiveGroup("FG1");
+
+    expect(mockedApi).toHaveBeenCalledWith({
+      url: "admin/productStores/STORE/facilityGroups/FG1/association",
+      method: "POST",
+      data: {
+        productStoreId: "STORE",
+        facilityGroupId: "FG1",
+        fromDate: 1781895000000,
+        thruDate: 1781896000000
+      }
+    });
+    expect(mockedApi).not.toHaveBeenCalledWith(expect.objectContaining({ url: "admin/facilityGroups/FG1" }));
+    expect(facilityGroupStore.getGroups).toEqual([]);
+    expect(facilityGroupStore.getGroupFacilities("FG1")).toEqual([]);
+  });
+
+  it("does not remove the group locally when the product store association cannot be identified", async () => {
+    useAtpProductStore().$patch({ currentProductStore: { productStoreId: "STORE" } });
+    const facilityGroupStore = useFacilityGroupStore();
+    facilityGroupStore.$patch({
+      groups: [{ facilityGroupId: "FG1", facilityGroupTypeId: "BROKERING_GROUP" }]
+    });
+
+    await expect(facilityGroupStore.archiveGroup("FG1")).rejects.toThrow("No active product store association found for facility group.");
+
+    expect(mockedApi).not.toHaveBeenCalled();
+    expect(facilityGroupStore.getGroups).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Business summary
Archiving a facility group removed it from local state but did not persist the selected product store relationship change, so the group could come back on refresh. The fix archives the active product-store/facility-group association row instead of issuing a global facility-group update that the selected-store list ignores.

## Code summary
- Change `facilityGroupStore.archiveGroup()` to `POST admin/productStores/{productStoreId}/facilityGroups/{facilityGroupId}/association` with the loaded association `fromDate` and a new `thruDate`.
- Stop removing the group locally when the selected product store or active association cannot be identified.
- Add a focused Pinia/Vitest regression test for the persisted archive request and missing-association failure path.

## Evidence
- Issue: https://github.com/hotwax/order-routing/issues/381
- Jam: https://jam.dev/c/54686ae6-069f-489b-ae13-1b30b8cbcaca
- Jam video shows the archive flow: group card -> Archive confirmation -> list updates to `No facility groups yet` after the action.
- Live `test-maarg` API reproduction with a throwaway group showed the current `PUT admin/facilityGroups/{id}` returned 200 but the group stayed in `admin/productStores/CODEX219/facilityGroups`.
- The same throwaway group disappeared from the selected-store list only after posting the association update with `productStoreId`, `facilityGroupId`, original `fromDate`, and `thruDate`.
- Local browser verification against `test-maarg` after the fix:
  - Seeded `Codex Archive 26727` via backend API.
  - Archived it through the UI.
  - Reloaded `/facility-groups`; the group stayed hidden and the API list no longer contained it.
- Screenshot evidence:

  ![Facility group before archive](https://github.com/hotwax/order-routing/releases/download/codex-order-routing-screenshots-20260620/issue-381-before-archive.png)

  ![Facility groups page immediately after archive](https://github.com/hotwax/order-routing/releases/download/codex-order-routing-screenshots-20260620/issue-381-after-archive.png)

  ![Facility groups page after reload confirming archive persisted](https://github.com/hotwax/order-routing/releases/download/codex-order-routing-screenshots-20260620/issue-381-after-reload.png)

## Why this layer
This is a frontend request-shaping bug. The backend endpoint already supports expiring the product-store association when the existing `fromDate` is included. No local server-side changes or backend workaround were used.

## Verification
- `git diff --check`
- `npm run test:unit -- tests/facilityGroupStore.test.ts --run`
- `npm run build`
- Browser run on `http://127.0.0.1:8130` authenticated against `test-maarg` and confirmed archive stays persisted after reload.

Closes #381
