### PR TITLE
UI adjustment and responsiveness

### DIFF
--- a/src/views/Inventory.vue
+++ b/src/views/Inventory.vue
@@ -31,7 +31,7 @@
           <ion-item lines="none">
             <ion-checkbox :checked="allSelected" :indeterminate="!allSelected && isAnyProductSelected" label-placement="end" @ionChange="selectAllProducts($event.detail.checked)">{{ "Select all" }}</ion-checkbox>
           </ion-item>
-          <div class="list-item" v-for="product in products" :key="product?.productId" @click="viewInventoryDetail(product.productId)">
+          <div class="list-item" v-for="product in products" :key="product.productId" @click="viewInventoryDetail(product.productId)">
             <ion-item>
               <ion-checkbox v-model="product.isChecked" slot="start" @click.stop></ion-checkbox>
               <ion-thumbnail data-testid="assigned-detail-product-thumbnail">
@@ -42,7 +42,7 @@
                 <p data-testid="assigned-detail-product-secondary-id">{{ product.productId }}</p>
               </ion-label>
             </ion-item>
-            <template v-if="product?.inventoryConfig">
+            <template v-if="product.inventoryConfig">
               <div>
                 <ion-label>
                   {{ product.inventoryConfig.atp }}

--- a/src/views/Inventory.vue
+++ b/src/views/Inventory.vue
@@ -245,10 +245,6 @@ async function openProductFacilityConfigModal(selectedProducts?: any[]) {
 </script>
 
 <style scoped>
-ion-content {
-  --padding-bottom: 80px;
-}
-
 .list-item {
   --columns-desktop: 6;
   border-bottom : 1px solid var(--ion-color-medium);

--- a/src/views/Inventory.vue
+++ b/src/views/Inventory.vue
@@ -87,11 +87,11 @@
         </template>
       </ion-list>
     </ion-content>
-    <ion-footer v-if="isAnyProductSelected">
+    <ion-footer>
       <ion-toolbar class="footer-actions">
         <ion-buttons>
-          <ion-button @click="openBulkInventoryEditModal">{{ "Adjust Inventory" }}</ion-button>
-          <ion-button @click="openProductFacilityConfigModal()">{{ "Adjust Config" }}</ion-button>
+          <ion-button :disabled="!isAnyProductSelected" @click="openBulkInventoryEditModal">{{ "Adjust Inventory" }}</ion-button>
+          <ion-button :disabled="!isAnyProductSelected" @click="openProductFacilityConfigModal()">{{ "Adjust Config" }}</ion-button>
         </ion-buttons>
       </ion-toolbar>
     </ion-footer>

--- a/src/views/Inventory.vue
+++ b/src/views/Inventory.vue
@@ -31,7 +31,7 @@
           <ion-item lines="none">
             <ion-checkbox :checked="allSelected" :indeterminate="!allSelected && isAnyProductSelected" label-placement="end" @ionChange="selectAllProducts($event.detail.checked)">{{ "Select all" }}</ion-checkbox>
           </ion-item>
-          <div class="list-item" v-for="product in products" :key="product.productId" @click="viewInventoryDetail(product.productId)">
+          <div class="list-item" v-for="product in products" :key="product?.productId" @click="viewInventoryDetail(product.productId)">
             <ion-item>
               <ion-checkbox v-model="product.isChecked" slot="start" @click.stop></ion-checkbox>
               <ion-thumbnail data-testid="assigned-detail-product-thumbnail">
@@ -42,7 +42,7 @@
                 <p data-testid="assigned-detail-product-secondary-id">{{ product.productId }}</p>
               </ion-label>
             </ion-item>
-            <template v-if="product.inventoryConfig">
+            <template v-if="product?.inventoryConfig">
               <div>
                 <ion-label>
                   {{ product.inventoryConfig.atp }}
@@ -253,6 +253,7 @@ ion-content {
   --columns-desktop: 6;
   border-bottom : 1px solid var(--ion-color-medium);
   align-items: center;
+  padding-right: 15px;
 }
 
 .list-item > ion-item {

--- a/src/views/Inventory.vue
+++ b/src/views/Inventory.vue
@@ -253,7 +253,7 @@ ion-content {
   --columns-desktop: 6;
   border-bottom : 1px solid var(--ion-color-medium);
   align-items: center;
-  padding-right: 15px;
+  padding-inline-end: var(--spacer-base, 16px);
 }
 
 .list-item > ion-item {

--- a/src/views/Inventory.vue
+++ b/src/views/Inventory.vue
@@ -87,11 +87,11 @@
         </template>
       </ion-list>
     </ion-content>
-    <ion-footer>
+    <ion-footer v-if="isAnyProductSelected">
       <ion-toolbar class="footer-actions">
         <ion-buttons>
-          <ion-button :disabled="!isAnyProductSelected" @click="openBulkInventoryEditModal">{{ "Adjust Inventory" }}</ion-button>
-          <ion-button :disabled="!isAnyProductSelected" @click="openProductFacilityConfigModal()">{{ "Adjust Config" }}</ion-button>
+          <ion-button @click="openBulkInventoryEditModal">{{ "Adjust Inventory" }}</ion-button>
+          <ion-button @click="openProductFacilityConfigModal()">{{ "Adjust Config" }}</ion-button>
         </ion-buttons>
       </ion-toolbar>
     </ion-footer>
@@ -245,6 +245,10 @@ async function openProductFacilityConfigModal(selectedProducts?: any[]) {
 </script>
 
 <style scoped>
+ion-content {
+  --padding-bottom: 80px;
+}
+
 .list-item {
   --columns-desktop: 6;
   border-bottom : 1px solid var(--ion-color-medium);


### PR DESCRIPTION
### Related Issues
Closes #374
This PR resolves two UI issues on the main Inventory list page (`src/views/Inventory.vue`):
jam: https://jam.dev/c/68c16bb3-fe75-499e-bf4a-6e5359e3a0e4

1. **Right Margin Alignment:** Added `padding-inline-end: var(--spacer-base, 16px)` to the inventory list items (`.list-item`) so that row elements and buttons no longer touch the absolute right edge of the screen.

### Screenshots of Visual Changes before/after (If There Are Any)
https://jam.dev/c/68c16bb3-fe75-499e-bf4a-6e5359e3a0e4

* **Padding Right Fix:** A uniform spacing is now maintained on the right side of the list rows.

### Contribution and Currently Important Rules Acceptance
- [x] I read and followed [contribution rules](https://github.com/hotwax/order-routing-rules#contribution-guideline)
