### PR TITLE
fix: override global grid layout on logs-panel

### DIFF
--- a/src/views/InventoryDetail.vue
+++ b/src/views/InventoryDetail.vue
@@ -363,6 +363,7 @@ ion-note[slot="end"] {
 
 .logs-panel {
   margin-top: var(--spacer-base, 16px);
+  display: block;
 }
 
 ion-badge {


### PR DESCRIPTION
This PR overrides the global grid layout rule on the logs-panel section in InventoryDetail.vue to ensure the log table headers and the empty state paragraph display as full-width block elements instead of being squished side-by-side.