### PR TITLE
Fix resolve unparsed translation variables in dashboard

### DIFF
--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -1,5 +1,6 @@
 import en from "./en.json"
 
 export default {
-  "en-US": en
+  "en-US": en,
+  "en": en
 };


### PR DESCRIPTION
### Related Issues
<!-- Put related issue number which this PR is closing. For example #123 -->
Closes #389

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Resolves an issue where `vue-i18n` failed to parse translation variables (like `{count}` and `{time}`) and instead rendered literal placeholders on the Dashboard. 
This PR applies two configuration fixes:
1. Updates `src/locales/index.ts` to export the dictionary under the `"en"` key as well, preventing the app's default `"en"` locale from falling back to raw keys.
2. Adds an alias in `vite.config.ts` for `'vue-i18n': 'vue-i18n/dist/vue-i18n.esm-bundler.js'` to ensure the runtime message compiler is bundled and capable of parsing dynamic string interpolations in the browser.

### Screenshots of Visual Changes 
Replaces literal placeholder text like `{count} scheduled` with actual numeric values like `3 scheduled`.

**Before**
<img width="1300" height="736" alt="not_fixed_unparsed" src="https://github.com/user-attachments/assets/cb29fa15-8240-4ec1-b16c-ed69a1eca05a" />

**After**
<img width="1300" height="736" alt="Fixed_unparsed_dashboard" src="https://github.com/user-attachments/assets/4dbe8528-c8ee-42c0-808c-273d821025b5" />
