### PR TITLE
Fixed: Pre-populate current configuration values when opening Adjust …

### DIFF
--- a/src/components/ProductFacilityConfigEditModal.vue
+++ b/src/components/ProductFacilityConfigEditModal.vue
@@ -44,7 +44,7 @@
 import { IonButton, IonButtons, IonContent, IonFab, IonFabButton, IonHeader, IonIcon, IonInput, IonSelect, IonSelectOption, IonTitle, IonToolbar, modalController } from "@ionic/vue";
 import { closeOutline, saveOutline } from "ionicons/icons";
 import { api, commonUtil, logger, translate } from '@common';
-import { ref } from "vue";
+import { onMounted, ref } from "vue";
 
 const props = defineProps(["selectedProducts", "selectedFacility"])
 
@@ -52,6 +52,18 @@ const allowPickup = ref("");
 const allowBrokering = ref("")
 const minimumStock = ref();
 const daysToShip = ref();
+
+onMounted(() => {
+  if (props.selectedProducts && props.selectedProducts.length === 1) {
+    const product = props.selectedProducts[0];
+    if (product.inventoryConfig) {
+      allowBrokering.value = product.inventoryConfig.allowBrokering ?? "";
+      allowPickup.value = product.inventoryConfig.allowPickup ?? "";
+      minimumStock.value = product.inventoryConfig.minimumStock;
+      daysToShip.value = product.inventoryConfig.daysToShip;
+    }
+  }
+});
 
 function closeModal() {
   modalController.dismiss();

--- a/src/components/ProductFacilityConfigEditModal.vue
+++ b/src/components/ProductFacilityConfigEditModal.vue
@@ -46,7 +46,7 @@ import { closeOutline, saveOutline } from "ionicons/icons";
 import { api, commonUtil, logger, translate } from '@common';
 import { onMounted, ref } from "vue";
 
-const props = defineProps(["selectedProducts", "selectedFacility"])
+const props = defineProps(["selectedProducts", "selectedFacility", "currentConfig"])
 
 const allowPickup = ref("");
 const allowBrokering = ref("")
@@ -54,14 +54,11 @@ const minimumStock = ref();
 const daysToShip = ref();
 
 onMounted(() => {
-  if (props.selectedProducts && props.selectedProducts.length === 1) {
-    const product = props.selectedProducts[0];
-    if (product.inventoryConfig) {
-      allowBrokering.value = product.inventoryConfig.allowBrokering ?? "";
-      allowPickup.value = product.inventoryConfig.allowPickup ?? "";
-      minimumStock.value = product.inventoryConfig.minimumStock;
-      daysToShip.value = product.inventoryConfig.daysToShip;
-    }
+  if (props.currentConfig) {
+    allowBrokering.value = props.currentConfig.allowBrokering ?? "";
+    allowPickup.value = props.currentConfig.allowPickup ?? "";
+    minimumStock.value = props.currentConfig.minimumStock;
+    daysToShip.value = props.currentConfig.daysToShip;
   }
 });
 

--- a/src/components/ProductInventoryEdit.vue
+++ b/src/components/ProductInventoryEdit.vue
@@ -47,7 +47,7 @@ import { api, commonUtil, logger, translate } from '@common';
 import { onMounted, ref } from "vue";
 import { useUserStore } from "@/store/userStore";
 
-const props = defineProps(["selectedProducts", "selectedFacility"])
+const props = defineProps(["selectedProducts", "selectedFacility", "currentConfig"])
 
 const variance = ref(0) as any;
 const varianceAction = ref("ADD")
@@ -89,7 +89,7 @@ async function updateInventory() {
     const varianceList = props.selectedProducts
       .map((item: any) => {
         return {
-          inventoryItemId: item.inventoryItemId,
+          inventoryItemId: props.currentConfig ? props.currentConfig.inventoryItemId : (item.inventoryItemId || item.inventoryConfig?.inventoryItemId),
           productId: item.productId,
           facilityId: props.selectedFacility,
           reasonEnumId,

--- a/src/views/InventoryDetail.vue
+++ b/src/views/InventoryDetail.vue
@@ -257,7 +257,8 @@ async function openConfigEditModal() {
     component: ProductFacilityConfigEditModal,
     componentProps: {
       selectedFacility: selectedFacilityId.value,
-      selectedProducts: inventoryConfig.value?.productId ? [inventoryConfig.value] : [{ productId: productId.value }]
+      selectedProducts: [{ productId: productId.value }],
+      currentConfig: inventoryConfig.value?.inventoryConfig
     }
   });
   await modal.present();

--- a/src/views/InventoryDetail.vue
+++ b/src/views/InventoryDetail.vue
@@ -257,7 +257,7 @@ async function openConfigEditModal() {
     component: ProductFacilityConfigEditModal,
     componentProps: {
       selectedFacility: selectedFacilityId.value,
-      selectedProducts: [{ productId: productId.value }]
+      selectedProducts: inventoryConfig.value ? [inventoryConfig.value] : [{ productId: productId.value }]
     }
   });
   await modal.present();

--- a/src/views/InventoryDetail.vue
+++ b/src/views/InventoryDetail.vue
@@ -257,7 +257,7 @@ async function openConfigEditModal() {
     component: ProductFacilityConfigEditModal,
     componentProps: {
       selectedFacility: selectedFacilityId.value,
-      selectedProducts: inventoryConfig.value ? [inventoryConfig.value] : [{ productId: productId.value }]
+      selectedProducts: inventoryConfig.value?.productId ? [inventoryConfig.value] : [{ productId: productId.value }]
     }
   });
   await modal.present();

--- a/src/views/InventoryDetail.vue
+++ b/src/views/InventoryDetail.vue
@@ -244,7 +244,8 @@ async function openInventoryEditModal() {
     component: ProductInventoryEdit,
     componentProps: {
       selectedFacility: selectedFacilityId.value,
-      selectedProducts: [{ productId: productId.value, inventoryItemId: inventoryConfig.value?.inventoryConfig?.inventoryItemId }]
+      selectedProducts: [{ productId: productId.value }],
+      currentConfig: inventoryConfig.value?.inventoryConfig
     }
   });
   await modal.present();


### PR DESCRIPTION
## Problem

When opening the **Adjust Config** modal from the Inventory Detail page, all form fields (Allow Brokering, Allow Pickup, Safety Stock, Days to Ship) default to empty/placeholder values instead of displaying the product's current configuration. This forces the user to re-enter all values even when only one field needs changing, risking accidental overwrites.
issue [refer screenshot]
<img width="1364" height="607" alt="image" src="https://github.com/user-attachments/assets/ee564f14-36a1-4bf4-a3e0-94108cf525fa" />


Closes #424
Solved [refer screenshot]
<img width="1364" height="607" alt="image" src="https://github.com/user-attachments/assets/92492e0c-6aa3-422b-9707-8c7d3b542fec" />

## Solution

### `InventoryDetail.vue`
- Updated `openConfigEditModal()` to pass the full `inventoryConfig` object (containing `inventoryConfig.allowBrokering`, `inventoryConfig.allowPickup`, etc.) via the `selectedProducts` prop, instead of only passing `{ productId }`.

### `ProductFacilityConfigEditModal.vue`
- Added `onMounted` lifecycle hook that checks if a single product is selected and pre-populates all form refs (`allowBrokering`, `allowPickup`, `minimumStock`, `daysToShip`) from `product.inventoryConfig`.
- The `v-model` two-way binding ensures users can still freely change any pre-filled value before saving.

## How was it tested?

- Opened the Inventory Detail page for a product with existing configuration.
- Clicked **Edit** on the Configuration card.
- Verified all four fields are pre-populated with current values.
- Changed one field and saved - confirmed only the changed field is updated.
- Verified bulk edit flow (multiple products selected from Inventory list) still opens with empty fields as intended.
