### PR TITLE
fix: resolve brokering runs popover not opening

### DIFF
--- a/src/views/BrokeringRuns.vue
+++ b/src/views/BrokeringRuns.vue
@@ -215,6 +215,22 @@ function redirect(group: Group) {
   router.push(`brokering/${group.routingGroupId}/routes`)
 }
 
+async function groupActionsPopover(group: Group, event: Event) {
+  const popover = await popoverController.create({
+    component: GroupActionsPopover,
+    event,
+    showBackdrop: false,
+    componentProps: { group }
+  });
+
+  popover.present();
+
+  const result = await popover.onDidDismiss();
+  if (result.data && result.data.routingGroups) {
+    brokeringGroups.value = JSON.parse(JSON.stringify(groups.value));
+  }
+}
+
 </script>
 
 <style scoped>

--- a/src/views/BrokeringRuns.vue
+++ b/src/views/BrokeringRuns.vue
@@ -227,7 +227,7 @@ async function groupActionsPopover(group: Group, event: Event) {
 
   const result = await popover.onDidDismiss();
   if (result.data && result.data.routingGroups) {
-    brokeringGroups.value = JSON.parse(JSON.stringify(groups.value));
+    brokeringGroups.value = result.data.routingGroups;
   }
 }
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
Fixes #431 

#

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fixed an issue where the three-dot popover menu on the Brokering Runs page was not opening when clicked. 

The `groupActionsPopover` method was triggered from the template but was missing in the `<script setup>` block. Added the missing function to successfully open the popover and handle run state updates (Move to Draft, Activate, Run now).


### Screenshots of Visual Changes 
<img width="1300" height="736" alt="Popover after" src="https://github.com/user-attachments/assets/0eff8a81-cc3b-4d80-abe4-8e8d5fd47715" />



