### PR TITLE
Fix inventory detail layout alignment and constraints

### DIFF
--- a/src/views/InventoryDetail.vue
+++ b/src/views/InventoryDetail.vue
@@ -277,6 +277,8 @@ ion-content {
   gap: var(--spacer-base, 16px);
   padding: var(--spacer-base, 16px);
   width: 100%;
+  max-width: 1600px;
+  margin: 0 auto;
   align-items: start;
 }
 
@@ -293,6 +295,8 @@ ion-content {
 
 .detail-grid {
   width: 100%;
+  max-width: 1600px;
+  margin: 0 auto;
   padding: var(--spacer-base, 16px);
 }
 
@@ -313,7 +317,7 @@ ion-content {
   height: 96px;
   overflow: hidden;
   border-radius: 8px;
-  margin:7px;
+  margin: 8px;
   background: var(--ion-color-step-100, #f4f5f8);
   color: var(--ion-color-medium);
   font-size: 32px;

--- a/src/views/InventoryDetail.vue
+++ b/src/views/InventoryDetail.vue
@@ -30,7 +30,7 @@
             </div>
           </ion-item>
 
-          <ion-card class="ion-margin-top">
+          <ion-card class="ion-no-margin ion-margin-top">
             <div class="card-header">
               <ion-card-header>
                 <ion-card-title>{{ translate("Inventory") }}</ion-card-title>
@@ -51,7 +51,7 @@
         </section>
 
         <div class="config-column">
-          <ion-card>
+          <ion-card class="ion-no-margin">
             <div class="card-header">
               <ion-card-header>
                 <ion-card-title>{{ translate("Configuration") }}</ion-card-title>
@@ -276,7 +276,7 @@ ion-content {
   grid-template-columns: 1fr 1fr;
   gap: var(--spacer-base, 16px);
   padding: var(--spacer-base, 16px);
-  max-width: 1280px;
+  width: 100%;
   align-items: start;
 }
 
@@ -292,7 +292,7 @@ ion-content {
 }
 
 .detail-grid {
-  max-width: 1280px;
+  width: 100%;
   padding: var(--spacer-base, 16px);
 }
 
@@ -313,6 +313,7 @@ ion-content {
   height: 96px;
   overflow: hidden;
   border-radius: 8px;
+  margin:7px;
   background: var(--ion-color-step-100, #f4f5f8);
   color: var(--ion-color-medium);
   font-size: 32px;


### PR DESCRIPTION
### Related to #433
### Closes #433  ### Fixes #433

### Short Description and Why It's Useful
This PR fixes some layout and alignment issues on the Inventory Detail page. 

**What changed:**
1. **Full-Width Layout:** I removed the hardcoded `max-width: 1280px` constraint from the detail layout. The page will now smoothly stretch to utilize 100% of the available width on larger monitors instead of awkwardly stopping and leaving empty space.
2. **Card Alignment:** I applied Ionic utility classes (`ion-no-margin`) to the Configuration and Inventory cards. This removes Ionic's default outer margins, ensuring the cards sit perfectly flush against the edges of the CSS grid without breaking alignment.
3. **Image Spacing:** Added a slight margin to the product image so it doesn't touch the borders of its container, giving it room to breathe.

### Screenshots of Visual Changes before/after (If There Are Any)
<img width="1363" height="615" alt="image" src="https://github.com/user-attachments/assets/f58c9be7-645f-4c8e-9468-9b9756dba590" />

### Contribution and Currently Important Rules Acceptance
- [x] I read and followed [contribution rules](https://github.com/hotwax/order-routing-rules#contribution-guideline)


