### PR TITLE
Implemented: tag counts + live matched-product total in pickup tag selector (#450)

### DIFF
--- a/src/components/AddProductFiltersModal.vue
+++ b/src/components/AddProductFiltersModal.vue
@@ -12,14 +12,15 @@
         <ion-button fill="clear" color="danger" :disabled="!facetOptions.length || !selectedValues.length" @click="selectedValues = []">{{ translate("Clear All") }}</ion-button>
       </ion-buttons>
     </ion-toolbar>
+    <ion-toolbar>
+      <ion-searchbar :placeholder="translate('Search', { label })" v-model="queryString" @keyup.enter="search()" />
+    </ion-toolbar>
   </ion-header>
 
   <ion-content>
-    <ion-searchbar :placeholder="translate('Search', { label })" v-model="queryString" @keyup.enter="search()"/>
-
     <div class="selected-chips" v-if="selectedValues.length">
       <ion-chip v-for="filter in selectedValues" outline :key="filter">
-        <ion-label>{{ filter }}</ion-label>
+        <ion-label>{{ countById[filter] != null ? `${filter}: ${countById[filter]}` : filter }}</ion-label>
         <ion-icon :icon="closeOutline" @click.stop="removeSelectedValue(filter)" />
       </ion-chip>
     </div>
@@ -38,12 +39,10 @@
     </div>
     <ion-list v-else-if="filteredOptions.length">
       <ion-item v-for="option in filteredOptions" :key="option.id" :button="!isAlreadyApplied(option.id)" @click="!isAlreadyApplied(option.id) ? updateSelectedValues(option.id) : null">
-        <ion-label v-if="isAlreadyApplied(option.id)">{{ option.label }}</ion-label>
-        <ion-checkbox v-else :checked="selectedValues.includes(option.id)">
-          {{ option.label }}
-        </ion-checkbox>
+        <ion-label>{{ option.label }}</ion-label>
         <ion-note v-if="countById[option.id] != null" slot="end">{{ countById[option.id] }}</ion-note>
         <ion-note v-if="isAlreadyApplied(option.id)" slot="end" color="danger">{{ type === 'included' ? translate("excluded") : translate("included") }}</ion-note>
+        <ion-checkbox v-if="!isAlreadyApplied(option.id)" slot="end" :checked="selectedValues.includes(option.id)" />
       </ion-item>
     </ion-list>
     <div class="empty-state" v-else-if="!queryString">

--- a/src/components/AddProductFiltersModal.vue
+++ b/src/components/AddProductFiltersModal.vue
@@ -97,6 +97,8 @@ const isLoading = ref(false);
 const matchedCount = ref(0);
 const isCountLoading = ref(false);
 let countTimer: any = null;
+let currentRequestId = 0;
+let isInitialLoad = true;
 
 const props = defineProps(["label", "facetToSelect", "searchfield", "type"]);
 const productStore = useAtpProductStore();
@@ -122,12 +124,18 @@ onUnmounted(() => {
 
 // Recompute the live total (debounced) whenever the modal-local selection changes.
 watch(selectedValues, () => {
+  // Skip the initial set in onMounted (refreshMatchedCount is already called there) to avoid a duplicate request.
+  if (isInitialLoad) {
+    isInitialLoad = false;
+    return;
+  }
   isCountLoading.value = true;
   if (countTimer) clearTimeout(countTimer);
   countTimer = setTimeout(refreshMatchedCount, 350);
 }, { deep: true })
 
 async function refreshMatchedCount() {
+  const requestId = ++currentRequestId;
   // Build a prospective applied-filters object: the saved filters with this side/field replaced by the
   // current unsaved modal selection, so the total reflects exactly what Save would produce.
   const prospectiveFilters = JSON.parse(JSON.stringify(appliedFilters.value))
@@ -138,6 +146,8 @@ async function refreshMatchedCount() {
     operator: appliedFiltersOperator.value,
     countOnly: true
   })
+  // Ignore a stale response that resolved after a newer request was issued.
+  if (requestId !== currentRequestId) return;
   matchedCount.value = total;
   isCountLoading.value = false;
 }

--- a/src/components/AddProductFiltersModal.vue
+++ b/src/components/AddProductFiltersModal.vue
@@ -16,11 +16,19 @@
 
   <ion-content>
     <ion-searchbar :placeholder="translate('Search', { label })" v-model="queryString" @keyup.enter="search()"/>
-    <ion-row>
-      <ion-chip v-for="filter in selectedValues" outline :key="filter.id">
+
+    <div class="selected-chips" v-if="selectedValues.length">
+      <ion-chip v-for="filter in selectedValues" outline :key="filter">
         <ion-label>{{ filter }}</ion-label>
+        <ion-icon :icon="closeOutline" @click.stop="removeSelectedValue(filter)" />
       </ion-chip>
-    </ion-row>
+    </div>
+
+    <!-- Live net matched-product total for the current (unsaved) modal selection. -->
+    <ion-item lines="none" class="match-summary">
+      <ion-spinner v-if="isCountLoading" name="dots" slot="start" />
+      <ion-label color="medium">{{ translate("{count} matching products", { count: matchedCount }) }}</ion-label>
+    </ion-item>
 
     <div class="empty-state" v-if="isLoading">
       <ion-item lines="none">
@@ -29,12 +37,13 @@
       </ion-item>
     </div>
     <ion-list v-else-if="filteredOptions.length">
-      <ion-item v-for="option in filteredOptions" :key="option.id"  @click="!isAlreadyApplied(option.id) ? updateSelectedValues(option.id) : null">
+      <ion-item v-for="option in filteredOptions" :key="option.id" :button="!isAlreadyApplied(option.id)" @click="!isAlreadyApplied(option.id) ? updateSelectedValues(option.id) : null">
         <ion-label v-if="isAlreadyApplied(option.id)">{{ option.label }}</ion-label>
-        <ion-checkbox v-if="!isAlreadyApplied(option.id)" :checked="selectedValues.includes(option.id)">
+        <ion-checkbox v-else :checked="selectedValues.includes(option.id)">
           {{ option.label }}
         </ion-checkbox>
-        <ion-note v-else slot="end" color="danger">{{ type === 'included' ? translate("excluded") : translate("included") }}</ion-note>
+        <ion-note v-if="countById[option.id] != null" slot="end">{{ countById[option.id] }}</ion-note>
+        <ion-note v-if="isAlreadyApplied(option.id)" slot="end" color="danger">{{ type === 'included' ? translate("excluded") : translate("included") }}</ion-note>
       </ion-item>
     </ion-list>
     <div class="empty-state" v-else-if="!queryString">
@@ -53,7 +62,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from "vue";
+import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import {
   IonButton,
   IonButtons,
@@ -68,7 +77,6 @@ import {
   IonLabel,
   IonList,
   IonNote,
-  IonRow,
   IonSearchbar,
   IonSpinner,
   IonTitle,
@@ -83,22 +91,56 @@ const facetOptions = ref([]) as any;
 const queryString = ref('');
 const selectedValues = ref([]) as any;
 const filteredOptions = ref([]) as any;
+const countById = ref<Record<string, number>>({});
 
 const isLoading = ref(false);
+const matchedCount = ref(0);
+const isCountLoading = ref(false);
+let countTimer: any = null;
 
 const props = defineProps(["label", "facetToSelect", "searchfield", "type"]);
 const productStore = useAtpProductStore();
 
 const appliedFilters = computed(() => productStore.getAppliedFilters);
+const appliedFiltersOperator = computed(() => productStore.getAppliedFiltersOperator);
 
 onMounted(async() => {
   isLoading.value = true;
   await productStore.fetchProductFilters({ facetToSelect: props.facetToSelect, searchfield: props.searchfield })
   facetOptions.value = productStore.getFacetOptions(props.searchfield);
   filteredOptions.value = [...facetOptions.value]
+  // Per-value product counts load independently so the option list isn't blocked on the count query.
+  productStore.fetchProductFacetCounts(props.searchfield).then((counts: Record<string, number>) => { countById.value = counts })
   selectedValues.value = JSON.parse(JSON.stringify((appliedFilters.value as any)[props.type][props.searchfield]))
   isLoading.value = false;
+  refreshMatchedCount();
 })
+
+onUnmounted(() => {
+  if (countTimer) clearTimeout(countTimer);
+})
+
+// Recompute the live total (debounced) whenever the modal-local selection changes.
+watch(selectedValues, () => {
+  isCountLoading.value = true;
+  if (countTimer) clearTimeout(countTimer);
+  countTimer = setTimeout(refreshMatchedCount, 350);
+}, { deep: true })
+
+async function refreshMatchedCount() {
+  // Build a prospective applied-filters object: the saved filters with this side/field replaced by the
+  // current unsaved modal selection, so the total reflects exactly what Save would produce.
+  const prospectiveFilters = JSON.parse(JSON.stringify(appliedFilters.value))
+  prospectiveFilters[props.type][props.searchfield] = selectedValues.value
+  isCountLoading.value = true;
+  const { total } = await productStore.previewProducts({
+    filters: prospectiveFilters,
+    operator: appliedFiltersOperator.value,
+    countOnly: true
+  })
+  matchedCount.value = total;
+  isCountLoading.value = false;
+}
 
 function closeModal() {
   modalController.dismiss({ dismissed: true });
@@ -121,6 +163,10 @@ function updateSelectedValues(value: string) {
   selectedValues.value.includes(value) ? selectedValues.value.splice(selectedValues.value.indexOf(value), 1) : selectedValues.value.push(value);
 }
 
+function removeSelectedValue(value: string) {
+  selectedValues.value = selectedValues.value.filter((filter: string) => filter !== value)
+}
+
 function isAlreadyApplied(value: string) {
   const type = props.type === 'included' ? 'excluded' : 'included'
   return (appliedFilters.value as any)[type][props.searchfield].includes(value)
@@ -140,12 +186,14 @@ async function saveFilters() {
     --padding-bottom: 80px;
   }
 
-  ion-row {
-    flex-wrap: nowrap;
-    overflow: scroll;
+  .selected-chips {
+    display: flex;
+    flex-wrap: wrap;
+    padding: 0 var(--spacer-sm, 8px);
   }
 
-  ion-chip {
-    flex-shrink: 0;
+  .match-summary {
+    --min-height: 36px;
+    font-size: 0.9rem;
   }
 </style>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -3,6 +3,7 @@
   "{count} blocking pickup": "{count} blocking pickup",
   "{count} blocking shipping": "{count} blocking shipping",
   "{count} draft": "{count} draft",
+  "{count} matching products": "{count} matching products",
   "{count} paused": "{count} paused",
   "{count} publish jobs": "{count} publish jobs",
   "{count} running": "{count} running",

--- a/src/store/atpProductStore.ts
+++ b/src/store/atpProductStore.ts
@@ -5,9 +5,12 @@ import { useUserStore } from '@/store/userStore'
 import { buildProductQuery } from '@/utils/productSync'
 
 // SOLR facet fields the applied product filters map to.
+// Solr FILTER fields used to build runSolrQuery filters. Note: `tagsFacet` / `productFeaturesFacet`
+// are facet-only fields (valid for the admin/solrFacets endpoint) and are NOT queryable on the PRODUCT
+// core — filtering on them returns an "undefined field" 400. The queryable fields are tags / productFeatures.
 const FILTER_FIELD_MAP: Record<string, string> = {
-  tags: 'tagsFacet',
-  productFeatures: 'productFeaturesFacet'
+  tags: 'tags',
+  productFeatures: 'productFeatures'
 }
 
 export interface ProductStoreState {
@@ -322,7 +325,7 @@ export const useAtpProductStore = defineStore('atpProductStore', {
             noConditionFind: 'Y',
             limit: 1000,
             offset,
-            searchfield: "tags",
+            searchfield: params.searchfield,
             term: params.queryString || "",
             q: params.queryString || ""
           }
@@ -344,6 +347,38 @@ export const useAtpProductStore = defineStore('atpProductStore', {
       }
       filters[params.searchfield] = allFacets
       this.facetOptions = filters;
+    },
+    // Per-value product counts for a facet field (e.g. how many products carry each tag), via a Solr
+    // terms facet. The admin/solrFacets options response only carries id/label/value, not counts.
+    async fetchProductFacetCounts(searchfield: string): Promise<Record<string, number>> {
+      const field = FILTER_FIELD_MAP[searchfield];
+      if (!field) return {};
+      try {
+        const resp = await api({
+          url: "admin/runSolrQuery",
+          method: "POST",
+          data: {
+            json: {
+              query: '(*:*)',
+              filter: ['docType:PRODUCT'],
+              params: { rows: 0 },
+              facet: { [searchfield]: { type: 'terms', field, limit: 1000 } }
+            }
+          }
+        }) as any;
+        if (!commonUtil.hasError(resp)) {
+          const buckets = resp.data?.facets?.[searchfield]?.buckets || [];
+          return buckets.reduce((map: Record<string, number>, bucket: any) => {
+            map[bucket.val] = bucket.count;
+            return map;
+          }, {} as Record<string, number>);
+        } else {
+          throw resp.data;
+        }
+      } catch (error) {
+        logger.error(error);
+      }
+      return {};
     },
     updatePickupGroupFacilities(payload: any) {
       this.pickupGroupFacilities = payload;
@@ -401,7 +436,11 @@ export const useAtpProductStore = defineStore('atpProductStore', {
       return facilities;
     },
     // Preview the products the current applied filters resolve to (read-only SOLR query).
-    async previewProducts(payload: { viewSize?: number; viewIndex?: number; keyword?: string } = {}) {
+    async previewProducts(payload: { viewSize?: number; viewIndex?: number; keyword?: string; filters?: any; operator?: any; countOnly?: boolean } = {}) {
+      // filters/operator default to the saved applied filters, but callers (e.g. the live matched-product
+      // total in the filter modal) can pass a prospective, unsaved selection to preview.
+      const filters = payload.filters || this.appliedFilters
+      const operator = payload.operator || this.appliedFiltersOperator
       const query = buildProductQuery({
         docType: 'PRODUCT',
         viewSize: payload.viewSize || 25,
@@ -410,20 +449,23 @@ export const useAtpProductStore = defineStore('atpProductStore', {
         fieldsToSelect: 'productId,productName,parentProductName,internalName,mainImageUrl'
       });
 
+      // Count-only callers just need numFound — skip fetching documents.
+      if (payload.countOnly) query.json.params.rows = 0;
+
       const quote = (value: string) => `"${String(value).replace(/"/g, '\\"')}"`;
 
-      Object.entries(this.appliedFilters.included).forEach(([key, values]: any) => {
+      Object.entries(filters.included || {}).forEach(([key, values]: any) => {
         const field = FILTER_FIELD_MAP[key];
         if (field && values?.length) {
-          const op = (this.appliedFiltersOperator.included as any)[key] === 'and' ? 'AND' : 'OR';
+          const op = (operator.included as any)?.[key] === 'and' ? 'AND' : 'OR';
           query.json.filter.push(`${field}: (${values.map(quote).join(` ${op} `)})`);
         }
       });
 
-      Object.entries(this.appliedFilters.excluded).forEach(([key, values]: any) => {
+      Object.entries(filters.excluded || {}).forEach(([key, values]: any) => {
         const field = FILTER_FIELD_MAP[key];
         if (field && values?.length) {
-          const op = (this.appliedFiltersOperator.excluded as any)[key] === 'or' ? 'OR' : 'AND';
+          const op = (operator.excluded as any)?.[key] === 'or' ? 'OR' : 'AND';
           query.json.filter.push(`-(${field}: (${values.map(quote).join(` ${op} `)}))`);
         }
       });

--- a/src/store/atpProductStore.ts
+++ b/src/store/atpProductStore.ts
@@ -366,7 +366,7 @@ export const useAtpProductStore = defineStore('atpProductStore', {
             }
           }
         }) as any;
-        if (!commonUtil.hasError(resp)) {
+        if (resp && !commonUtil.hasError(resp)) {
           const buckets = resp.data?.facets?.[searchfield]?.buckets || [];
           return buckets.reduce((map: Record<string, number>, bucket: any) => {
             map[bucket.val] = bucket.count;


### PR DESCRIPTION
Resolves #450. Adds decision context to the product-tag selector (`AddProductFiltersModal`) used by Store Pickup rule product filters.

## Changes
- **Per-tag product counts** on each option row (`ion-note slot="end"`), from a Solr terms facet (`fetchProductFacetCounts`) — the `admin/solrFacets` options response only returns id/label/value, no counts.
- **Live net matched-product total** for the current *unsaved* modal selection (`N matching products`). Debounced; updates on check/uncheck, chip removal, and Clear All; respects include/exclude side, the AND/OR operator, and the other already-applied filters.
- **Removable selected chips** (close icon) — removes the tag from the selection without closing the modal.

## Store (`atpProductStore`)
- `previewProducts()` gains optional `filters` / `operator` overrides + `countOnly` (backward-compatible) so the modal can preview the prospective selection's total.
- New `fetchProductFacetCounts(searchfield)` → `{ value: count }` via a `runSolrQuery` terms facet.
- `fetchProductFilters()` uses `params.searchfield` (was hardcoded `"tags"`).
- **`FILTER_FIELD_MAP` corrected to the queryable Solr fields `tags` / `productFeatures`.** The `*Facet` variants are facet-only and return `400 undefined field` as `runSolrQuery` filters — so the existing **"Matched products" preview was silently matching 0** for any rule with tag/feature filters. This fixes that too.

## Verified live on demo-oms (`hotwax.user`)
Rule M100153 (tags Men, Sale): per-tag counts render (Men 989, Women 865, Bottom 360, …); live total shows `989 matching products` and updates reactively to `1849` when Women is added; chips have close icons and remove on click. `npm run build` ✅.

Note: touches `atpProductStore.ts`, which the sibling #451 (facility-group selector) will also touch — they'll be reconciled.

Stacked on the integration branch `codex/integration-prs-428-434-437`.