### PR TITLE
Fixed: Product Store identifier preference never loads (dataDocumentView 400) (#454)

### DIFF
--- a/src/store/productStore.ts
+++ b/src/store/productStore.ts
@@ -126,9 +126,11 @@ export const productStore = defineStore('productStore', {
             params: { settingTypeEnumId: "PRDT_IDEN_PREF" }
           }) as any
 
-          if (!commonUtil.hasError(resp) && Array.isArray(resp.data)) {
+          if (resp && !commonUtil.hasError(resp) && Array.isArray(resp.data)) {
             resp.data.forEach((productSetting: any) => {
-              productStoreSettings[productSetting.settingTypeEnumId] = productSetting.settingValue
+              if (productSetting?.settingTypeEnumId) {
+                productStoreSettings[productSetting.settingTypeEnumId] = productSetting.settingValue
+              }
             })
           }
         } catch (error) {

--- a/src/store/productStore.ts
+++ b/src/store/productStore.ts
@@ -115,26 +115,22 @@ export const productStore = defineStore('productStore', {
       const productStoreSettings = {} as any
 
       if (productStoreId) {
-        const payload = {
-          productStoreId,
-          settingTypeEnumId: ["PRDT_IDEN_PREF"],
-          settingTypeEnumId_op: "in",
-          pageIndex: 0,
-          pageSize: 50
-        }
         try {
+          // Read via the admin ProductStoreSetting REST endpoint (same family as the write path in
+          // setProductStoreSetting). The "ProductStoreSetting" dataDocument is not registered on the OMS,
+          // so the previous POST /oms/dataDocumentView returned 400 ("No DataDocument found") and the
+          // identifier preference silently fell back to defaults (#454).
           const resp = await api({
-            url: `/oms/dataDocumentView`,
-            method: "POST",
-            data: {
-              dataDocumentId: "ProductStoreSetting",
-              customParametersMap: payload
-            }
+            url: `admin/productStores/${productStoreId}/settings`,
+            method: "GET",
+            params: { settingTypeEnumId: "PRDT_IDEN_PREF" }
           }) as any
 
-          resp?.data?.entityValueList?.forEach((productSetting: any) => {
-            productStoreSettings[productSetting.settingTypeEnumId] = productSetting.settingValue
-          })
+          if (!commonUtil.hasError(resp) && Array.isArray(resp.data)) {
+            resp.data.forEach((productSetting: any) => {
+              productStoreSettings[productSetting.settingTypeEnumId] = productSetting.settingValue
+            })
+          }
         } catch (error) {
           logger.error("Failed to fetch settings", error)
         }


### PR DESCRIPTION
Resolves #454.

`fetchProductStoreSettings()` POSTed `/oms/dataDocumentView` with `dataDocumentId: "ProductStoreSetting"`, which returns **400 "No DataDocument found with ID ProductStoreSetting"** on the OMS — that dataDocument isn't registered on demo-maarg. The error was swallowed, so `PRDT_IDEN_PREF` never loaded and the product-identifier preference silently fell back to `SKU`/`productId` everywhere it's read (#439/#446 Settings card, #441/#447 Inventory Detail header), which is also the root of the #446 "Primary select shows its placeholder" symptom.

## Investigation (live on demo-maarg, `hotwax.user`)
Tested the endpoint directly with multiple param shapes — **all** returned the same `No DataDocument found` 400, confirming it's a missing-dataDocument (backend/data) gap, not a client param-shape bug. But `GET admin/productStores/STORE/settings?settingTypeEnumId=PRDT_IDEN_PREF` returns **200** with the real saved value:
```
[{ "productStoreId":"STORE", "settingTypeEnumId":"PRDT_IDEN_PREF", "settingValue":"{\"primaryId\":\"SKU\",\"secondaryId\":\"productId\"}" }]
```

## Fix
Switch the read to `GET admin/productStores/{productStoreId}/settings` (the **same endpoint family** the write path `setProductStoreSetting` already uses), filtered by `settingTypeEnumId=PRDT_IDEN_PREF`, mapping `settingTypeEnumId -> settingValue`. Downstream `JSON.parse(settingValue)` is unchanged; still degrades cleanly on error.

## Verified
After the change, `/settings` loads with **no** `Failed to fetch settings` 400 in the console, and the working endpoint returns the saved preference. `npm run build` ✅.

Unblocks the actual functionality of #446 (Settings selector) and #447 (Inventory Detail header) — they'll now reflect the saved preference instead of always defaulting. Stacked on the integration branch.