### PR TITLE
Fix Circuit proximity measurement chip height (#460)

### DIFF
--- a/src/components/circuit/CircuitCanvas.vue
+++ b/src/components/circuit/CircuitCanvas.vue
@@ -2263,6 +2263,15 @@ async function openArchivedRoutingModal() {
 
 <style scoped>
 
+/* The measurement-unit and operator selectors nest an ion-select inside an
+   ion-chip. The modern (non-legacy) ion-select applies its own min-height,
+   which makes those chips taller than the adjacent value chips and breaks the
+   row alignment (most visible in dark mode). Drop the inherited min-height so
+   the chip sizes to the select's content, matching BrokeringQuery.vue. */
+ion-chip > ion-select {
+  min-height: unset;
+}
+
 .circuit-canvas {
   display: grid;
   grid-template-columns: repeat(6, 350px);


### PR DESCRIPTION
Closes #460.

## Problem

In the Circuit inventory rule editor, the Proximity **measurement-unit** selector renders as a too-tall chip (very visible in dark mode), taller than the adjacent numeric value chip, breaking the row's alignment. Root cause: the selector nests an `ion-select` directly inside an `ion-chip` (`CircuitCanvas.vue:387-392`), and the modern (non-legacy) `ion-select` applies its own `min-height` that drives the chip height.

## Fix

Add a scoped one-liner to `CircuitCanvas.vue`'s `<style scoped>` block:

```css
ion-chip > ion-select {
  min-height: unset;
}
```

This is the **same minimal override `BrokeringQuery.vue` already uses** (`BrokeringQuery.vue:1821-1824`) for the identical nested-select-in-chip pattern — so it follows existing convention rather than introducing a new approach. Being `scoped`, it only affects Circuit.

It also covers the **Brokering safety-stock operator** chip (`CircuitCanvas.vue:399-404`), which the issue asks to review — it uses the same `ion-chip > ion-select` structure and gets the same correction.

Presentation only — no behavior change: selecting `kms`/`miles` still updates `MEASUREMENT_SYSTEM`, the operator still updates `BRK_SAFETY_STOCK`, and the existing `chipClickEvent` click/keyboard path is untouched.

## Verification

- ✅ `npm run build` (vite) passes.
- The fix is a CSS height reset identical to the proven `BrokeringQuery` override for the same Ionic pattern. A live dark-mode screenshot of the rendered Circuit card isn't included — the authenticated Circuit view can't be driven in the throwaway preview origin (DXP launchpad OAuth + Mastra backend), so this relies on the established in-repo pattern + the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)