### PR TITLE
Mount Fast Travel in Order Routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,15 +28,3 @@ VITE_SIM_PRODUCT_STORE_ID="STORE"
 # guards the /simulate* routes). Set "false" where the brokering simulation isn't ready to expose.
 VITE_SIMULATION_ENABLED="true"
 
-# --- Fast Travel (cross-app router) ---
-# Base URLs for deep links into sibling HotWax apps. Set per deployment; blank = that app is shown
-# disabled and its deep links are hidden.
-VITE_LAUNCHPAD_URL="https://launchpad.hotwax.io"
-VITE_ORDER_MANAGER_URL=""
-VITE_ORDER_ROUTING_URL=""
-VITE_JOB_MANAGER_URL=""
-VITE_COMPANY_URL=""
-VITE_PRODUCTS_URL=""
-VITE_PREORDER_URL=""
-VITE_TRANSFERS_URL=""
-VITE_CYCLE_COUNT_URL=""

--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,16 @@ VITE_SIM_PRODUCT_STORE_ID="STORE"
 # Show the Simulate tab/feature for this deployment. Default shown: only "false" hides it (also
 # guards the /simulate* routes). Set "false" where the brokering simulation isn't ready to expose.
 VITE_SIMULATION_ENABLED="true"
+
+# --- Fast Travel (cross-app router) ---
+# Base URLs for deep links into sibling HotWax apps. Set per deployment; blank = that app is shown
+# disabled and its deep links are hidden.
+VITE_LAUNCHPAD_URL="https://launchpad.hotwax.io"
+VITE_ORDER_MANAGER_URL=""
+VITE_ORDER_ROUTING_URL=""
+VITE_JOB_MANAGER_URL=""
+VITE_COMPANY_URL=""
+VITE_PRODUCTS_URL=""
+VITE_PREORDER_URL=""
+VITE_TRANSFERS_URL=""
+VITE_CYCLE_COUNT_URL=""

--- a/src/App.vue
+++ b/src/App.vue
@@ -112,7 +112,7 @@
       <ion-router-outlet id="main-content" />
     </ion-split-pane>
     <!-- Fast Travel: Cmd/Ctrl+K app switcher + deep-link router across the HotWax suite -->
-    <FastTravel current-app="order-routing" />
+    <FastTravel v-if="useAuth().isAuthenticated" current-app="order-routing" />
   </ion-app>
 </template>
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -111,6 +111,8 @@
       </ion-menu>
       <ion-router-outlet id="main-content" />
     </ion-split-pane>
+    <!-- Fast Travel: Cmd/Ctrl+K app switcher + deep-link router across the HotWax suite -->
+    <FastTravel current-app="order-routing" />
   </ion-app>
 </template>
 
@@ -141,7 +143,7 @@ import {
 import { computed, onBeforeMount, onMounted, onUnmounted, ref } from "vue";
 import { gridOutline } from "ionicons/icons";
 import { Settings } from "luxon";
-import { commonUtil, emitter, translate } from "@common";
+import { commonUtil, emitter, FastTravel, translate } from "@common";
 import { useAuth } from "@common/composables/useAuth";
 import { useUserStore } from "@/store/userStore";
 import { useAtpProductStore } from "@/store/atpProductStore";


### PR DESCRIPTION
## Business summary
Adds the shared AccxUI Fast Travel entry point to Order Routing so operators can use Cmd/Ctrl+K to move between configured HotWax admin apps from the app shell.

Closes #491

## Scope
- Mounts the shared `FastTravel` component in the root app shell with `order-routing` as the current app id.
- Documents sibling app URL variables in `.env.example` so deployments can enable the destinations they support.
- Keeps unconfigured destinations disabled through the shared registry behavior.

## Verification
- `./node_modules/.bin/vite build` passed in a clean PR worktree using AccxUI shared `common` and root `node_modules` symlinks.