### PR TITLE
feat: select all toggle for channels in threshold rules

### DIFF
--- a/src/views/CreateUpdateThresholdRule.vue
+++ b/src/views/CreateUpdateThresholdRule.vue
@@ -131,8 +131,16 @@ onIonViewDidEnter(async () => {
         formData.value.threshold = currentRule.value.ruleActions[0]?.fieldValue ? currentRule.value.ruleActions[0].fieldValue : ''
 
         const facilityCondition = currentRule.value.ruleConditions.find((condition: any) => condition.conditionTypeEnumId === "ENTCT_ATP_FACILITIES")
-        if(facilityCondition?.fieldValue === "ALL") formData.value.areAllChannelsSelected = true
-        else formData.value.selectedConfigFacilites = facilityCondition?.fieldValue ? facilityCondition.fieldValue?.split(",") : [];
+        if(facilityCondition?.fieldValue === "ALL") {
+          if (configFacilities.value.length <= 1) {
+            formData.value.areAllChannelsSelected = false;
+            formData.value.selectedConfigFacilites = configFacilities.value.map((facility: any) => facility.facilityId);
+          } else {
+            formData.value.areAllChannelsSelected = true;
+          }
+        } else {
+          formData.value.selectedConfigFacilites = facilityCondition?.fieldValue ? facilityCondition.fieldValue?.split(",") : [];
+        }
 
         const currentAppliedFilters = JSON.parse(JSON.stringify(appliedFilters.value))
         const currentAppliedFiltersOperator = JSON.parse(JSON.stringify(appliedFiltersOperator.value))
@@ -194,7 +202,7 @@ function toggleFacilitySelection(facilityId: any) {
 }
 
 function isFacilitySelected(facilityId: any) {
-  return formData.value.areAllChannelsSelected || formData.value.selectedConfigFacilites?.includes(facilityId)
+  return !!(formData.value.areAllChannelsSelected || formData.value.selectedConfigFacilites?.includes(facilityId))
 }
 
 async function createThresholdRule() {

--- a/src/views/CreateUpdateThresholdRule.vue
+++ b/src/views/CreateUpdateThresholdRule.vue
@@ -34,7 +34,7 @@
         <h1>{{ translate("Channels") }} <ion-text color="danger">*</ion-text></h1>
       </div>
 
-      <section>
+      <section v-if="configFacilities.length > 1">
         <ion-item lines="none">
           <ion-toggle v-model="formData.areAllChannelsSelected">{{ translate("Select all channels") }}</ion-toggle>
         </ion-item>
@@ -194,7 +194,7 @@ function toggleFacilitySelection(facilityId: any) {
 }
 
 function isFacilitySelected(facilityId: any) {
-  return formData.value.selectedConfigFacilites?.includes(facilityId)
+  return formData.value.areAllChannelsSelected || formData.value.selectedConfigFacilites?.includes(facilityId)
 }
 
 async function createThresholdRule() {


### PR DESCRIPTION
### Related Issues
Closes #372 

### Short Description and Why It's Useful
Added logic to handle the "Select all channels" toggle when creating or updating threshold rules. 
- The "Select all channels" toggle will now only be displayed if there is more than 1 channel (`configFacilities.length > 1`) available to select.
- Updated the `isFacilitySelected` check to automatically return `true` for all channels if the `areAllChannelsSelected` toggle is enabled.


### Screenshots of Visual Changes 
No Channels
<img width="1300" height="736" alt="Zero_Channels" src="https://github.com/user-attachments/assets/ecab7f85-6bcb-4d17-815c-2bdc0cc86527" />

Only One Channel
<img width="1300" height="736" alt="One_Channel" src="https://github.com/user-attachments/assets/4885e0da-3dbd-449e-b011-708e5fd6585b" />

More than one channel
<img width="1300" height="736" alt="Two_channels" src="https://github.com/user-attachments/assets/bc3138b3-39e1-42cc-9f9a-12d2283cd926" />

When "Select all Channels" toggle is on
<img width="1300" height="736" alt="All_channels_selected" src="https://github.com/user-attachments/assets/8c9a6b6b-0625-48d5-886b-9bed0209874e" />

