### PR TITLE
Fix stale product-store selector after switching OMS instance

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -29,6 +29,7 @@ import "./theme/variables.css";
 import { createPinia } from "pinia";
 import piniaPluginPersistedstate from "pinia-plugin-persistedstate";
 import { logger, createDxpI18n, initialiseConfig } from "@common";
+import { useAuth } from "@common/composables/useAuth";
 import localeMessages from "./locales"
 import { useUserStore } from "@/store/userStore";
 import { initialize } from "@/services/appInitializer";
@@ -61,6 +62,14 @@ router.isReady().then(async () => {
     await initialize()
   } catch (error) {
     logger.error('[IndexedDB] Failed to open CommonDB', error)
+  }
+
+  // Hydrated Pinia state may belong to a previously linked OMS instance (switch without
+  // logout); validate before mount so no page renders another instance's product stores.
+  try {
+    await useUserStore().ensureInstanceScope({ refetch: useAuth().isAuthenticated.value })
+  } catch (error) {
+    logger.error('Failed to validate OMS instance scope on hydrate', error)
   }
 
   app.mount("#app");

--- a/src/store/atpProductStore.ts
+++ b/src/store/atpProductStore.ts
@@ -3,6 +3,7 @@ import { api, logger, commonUtil } from '@common'
 import { DateTime } from 'luxon'
 import { useUserStore } from '@/store/userStore'
 import { buildProductQuery } from '@/utils/productSync'
+import { getOmsInstanceKey } from '@/utils/omsInstance'
 
 // SOLR facet fields the applied product filters map to.
 // Solr FILTER fields used to build runSolrQuery filters. Note: `tagsFacet` / `productFeaturesFacet`
@@ -16,6 +17,9 @@ const FILTER_FIELD_MAP: Record<string, string> = {
 export interface ProductStoreState {
   productStores: any[]
   currentProductStore: any
+  // OMS instance the persisted product stores were fetched from; state is dropped when it
+  // no longer matches the connected instance (see userStore.ensureInstanceScope).
+  omsInstanceKey: string
   configFacilities: any[];
   appliedFilters: {
     included: {
@@ -52,6 +56,7 @@ export const useAtpProductStore = defineStore('atpProductStore', {
   state: (): ProductStoreState => ({
     productStores: [],
     currentProductStore: {},
+    omsInstanceKey: "",
     configFacilities: [],
     appliedFilters: {
       included: {
@@ -115,6 +120,7 @@ export const useAtpProductStore = defineStore('atpProductStore', {
         // Disallow login if the user is not associated with any product store
         if (!commonUtil.hasError(resp)) {
           this.productStores = resp.data
+          this.omsInstanceKey = getOmsInstanceKey()
         } else {
           throw resp.data;
         }

--- a/src/store/atpProductStore.ts
+++ b/src/store/atpProductStore.ts
@@ -112,15 +112,20 @@ export const useAtpProductStore = defineStore('atpProductStore', {
       this.currentProductStore = productStore;
     },
     async fetchUserProductStores() {
+      const requestedInstanceKey = getOmsInstanceKey();
       try {
         const resp = await api({
           url: "admin/user/productStore",
           method: "GET"
         });
+        if (getOmsInstanceKey() !== requestedInstanceKey) {
+          logger.warn("Discarding ATP product stores response because OMS instance changed in flight");
+          return;
+        }
         // Disallow login if the user is not associated with any product store
         if (!commonUtil.hasError(resp)) {
           this.productStores = resp.data
-          this.omsInstanceKey = getOmsInstanceKey()
+          this.omsInstanceKey = requestedInstanceKey
         } else {
           throw resp.data;
         }

--- a/src/store/productStore.ts
+++ b/src/store/productStore.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { logger, commonUtil, api, translate } from '@common'
 import { orderRoutingStore } from './orderRoutingStore'
 import { useUtilStore } from './utilStore'
+import { getOmsInstanceKey } from '@/utils/omsInstance'
 
 interface ProductStoreReferenceDataPayload {
   productStoreId?: string;
@@ -17,6 +18,9 @@ export const productStore = defineStore('productStore', {
     return {
       ecomStores: [] as any,
       currentEComStore: {} as any,
+      // OMS instance the persisted ecomStores were fetched from; state is dropped when it
+      // no longer matches the connected instance (see userStore.ensureInstanceScope).
+      omsInstanceKey: '' as string,
       facilities: {} as any,
       shippingMethods: {} as any,
       facilityGroups: {} as any,
@@ -102,6 +106,7 @@ export const productStore = defineStore('productStore', {
         } else {
           this.ecomStores = resp.data;
           this.currentEComStore = resp.data[0];
+          this.omsInstanceKey = getOmsInstanceKey();
           await this.fetchProductStoreSettings(this.currentEComStore.productStoreId);
           return Promise.resolve(resp.data);
         }

--- a/src/store/productStore.ts
+++ b/src/store/productStore.ts
@@ -95,18 +95,23 @@ export const productStore = defineStore('productStore', {
   },
   actions: {
     async fetchProductStores(): Promise<any> {
+      const requestedInstanceKey = getOmsInstanceKey();
       try {
         const resp = await api({
           url: "admin/user/productStore",
           method: "GET",
           baseURL : commonUtil.getMaargURL(),
         });
+        if (getOmsInstanceKey() !== requestedInstanceKey) {
+          logger.warn("Discarding product stores response because OMS instance changed in flight");
+          return Promise.resolve([]);
+        }
         if (commonUtil.hasError(resp) || resp.data.length === 0) {
           throw resp.data;
         } else {
           this.ecomStores = resp.data;
           this.currentEComStore = resp.data[0];
-          this.omsInstanceKey = getOmsInstanceKey();
+          this.omsInstanceKey = requestedInstanceKey;
           await this.fetchProductStoreSettings(this.currentEComStore.productStoreId);
           return Promise.resolve(resp.data);
         }

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -8,6 +8,7 @@ import { productStore as useProduct } from './product'
 import { productStore } from './productStore'
 import { useProductInventoryStore } from './productInventory'
 import { initialize } from '@/services/appInitializer'
+import { isInstanceScopeStale } from '@/utils/omsInstance'
 import { useAtpProductStore } from './atpProductStore'
 import { useRuleStore } from './rule'
 import { useChannelStore } from './channel'
@@ -151,6 +152,9 @@ export const useUserStore = defineStore('user', {
         await this.fetchUserProfile()
         await this.setOms(cookieHelper().get("oms"))
         await initialize()
+        // Drop caches persisted while linked to a different OMS before refetching below,
+        // so a fetch failure can't leave another instance's product stores selected.
+        await this.ensureInstanceScope()
         await this.fetchPermissions()
         await productStore().fetchProductStores()
         await this.fetchAvailableTimeZones()
@@ -170,6 +174,13 @@ export const useUserStore = defineStore('user', {
       }
     },
     async postLogout() {
+      await this.clearInstanceScopedState()
+
+      this.$reset();
+    },
+    // Clears every store whose persisted data only makes sense on the OMS instance it was
+    // fetched from. Used on logout and when a login/hydrate detects an instance switch.
+    async clearInstanceScopedState(): Promise<void> {
       orderRoutingStore().clearRouting()
       orderRoutingStore().clearRoutingTestInfo()
       useUtilStore().clearUtilState()
@@ -179,8 +190,39 @@ export const useUserStore = defineStore('user', {
       useAtpProductStore().$reset()
       useRuleStore().$reset()
       useChannelStore().$reset()
+    },
+    // Persisted Pinia state survives OMS instance switches that happen without an explicit
+    // logout (launchpad switch, relogin to another instance), leaving product stores from
+    // the previously linked instance selected. Compares the instance key stamped on the
+    // product-store caches against the connected instance and drops all instance-scoped
+    // state on mismatch. Returns whether the persisted state was already valid.
+    async ensureInstanceScope(payload?: { refetch?: boolean }): Promise<boolean> {
+      const atp = useAtpProductStore()
+      const ecom = productStore()
+      const atpStale = isInstanceScopeStale(atp.omsInstanceKey, Boolean(atp.productStores?.length || atp.currentProductStore?.productStoreId))
+      const ecomStale = isInstanceScopeStale(ecom.omsInstanceKey, Boolean(ecom.ecomStores?.length || ecom.currentEComStore?.productStoreId))
+      if (!atpStale && !ecomStale) return true
 
-      this.$reset();
+      await this.clearInstanceScopedState()
+
+      // On app hydrate there is no login flow to repopulate the selector, so refetch here.
+      if (payload?.refetch) {
+        try {
+          await ecom.fetchProductStores()
+        } catch (error) {
+          logger.error("Failed to fetch product stores for the connected OMS", error)
+        }
+        try {
+          await atp.fetchUserProductStores()
+          const stores = atp.getProductStores
+          if (stores && stores.length) {
+            atp.setCurrentProductStore(stores[0])
+          }
+        } catch (error) {
+          logger.error("Failed to fetch sourcing product stores for the connected OMS", error)
+        }
+      }
+      return false
     },
     async setUserTimeZone(payload: any) {
       const current: any = this.current;

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -181,6 +181,8 @@ export const useUserStore = defineStore('user', {
     // Clears every store whose persisted data only makes sense on the OMS instance it was
     // fetched from. Used on logout and when a login/hydrate detects an instance switch.
     async clearInstanceScopedState(): Promise<void> {
+      this.current = null
+      this.permissions = []
       orderRoutingStore().clearRouting()
       orderRoutingStore().clearRoutingTestInfo()
       useUtilStore().clearUtilState()
@@ -207,6 +209,12 @@ export const useUserStore = defineStore('user', {
 
       // On app hydrate there is no login flow to repopulate the selector, so refetch here.
       if (payload?.refetch) {
+        try {
+          await this.fetchUserProfile()
+          await this.fetchPermissions()
+        } catch (error) {
+          logger.error("Failed to fetch user profile or permissions for the connected OMS", error)
+        }
         try {
           await ecom.fetchProductStores()
         } catch (error) {

--- a/src/utils/omsInstance.ts
+++ b/src/utils/omsInstance.ts
@@ -1,0 +1,18 @@
+import { commonUtil } from "@common";
+
+// Identity of the OMS instance the app is currently linked to, derived from the same
+// cookie-backed source the api layer resolves its base URL from. The full URL (not just
+// the instance name) is used so local instances differing only by port don't collide.
+export function getOmsInstanceKey(): string {
+  return (commonUtil.getOmsURL() || "").trim().toLowerCase();
+}
+
+// Persisted product-store caches are only trustworthy on the instance they were fetched
+// from. A cache holding data without a recorded key predates instance stamping and cannot
+// be attributed to the connected instance, so it is treated as stale too. With no connected
+// instance (no oms cookie) there is nothing to compare against — the login flow revalidates.
+export function isInstanceScopeStale(recordedKey: string | undefined, hasData: boolean): boolean {
+  const currentKey = getOmsInstanceKey();
+  if (!currentKey || !hasData) return false;
+  return recordedKey !== currentKey;
+}

--- a/tests/omsInstanceScope.test.ts
+++ b/tests/omsInstanceScope.test.ts
@@ -1,0 +1,151 @@
+// tests/omsInstanceScope.test.ts
+// Persisted Pinia product-store caches are stamped with the OMS instance they were fetched
+// from; userStore.ensureInstanceScope drops all instance-scoped state when the stamp no
+// longer matches the connected instance (login or hydrate after an instance switch).
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+
+const mocks = vi.hoisted(() => ({
+  api: vi.fn(),
+  omsUrl: { value: "https://demo-oms.hotwax.io/api/" },
+}));
+
+vi.mock("@common", () => ({
+  api: mocks.api,
+  logger: { error: () => {}, warn: () => {}, info: () => {} },
+  translate: (key: string) => key,
+  emitter: { on: () => {}, off: () => {}, emit: () => {} },
+  cookieHelper: () => ({ get: () => null, set: () => {}, remove: () => {} }),
+  commonUtil: {
+    getOmsURL: () => mocks.omsUrl.value,
+    getMaargURL: () => mocks.omsUrl.value,
+    hasError: (resp: any) => resp?._error === true,
+    showToast: () => {},
+  },
+}));
+vi.mock("@common/composables/useAuth", () => ({
+  useAuth: () => ({ updateUserId: () => {} }),
+}));
+vi.mock("@common/core/workerFactory", () => ({ WorkerFactory: class {} }));
+vi.mock("@/services/appInitializer", () => ({
+  initialize: vi.fn(),
+  clearProductCache: vi.fn(),
+  db: {},
+}));
+
+import { useUserStore } from "../src/store/userStore";
+import { useAtpProductStore } from "../src/store/atpProductStore";
+import { productStore } from "../src/store/productStore";
+import { useChannelStore } from "../src/store/channel";
+import { useRuleStore } from "../src/store/rule";
+import { getOmsInstanceKey, isInstanceScopeStale } from "../src/utils/omsInstance";
+
+const DEMO_KEY = "https://demo-oms.hotwax.io/api/";
+const OLD_KEY = "https://old-oms.hotwax.io/api/";
+
+function seedInstanceState(instanceKey: string) {
+  const atp = useAtpProductStore();
+  atp.productStores = [{ productStoreId: "CAT_STORE", storeName: "CAT" }];
+  atp.currentProductStore = { productStoreId: "CAT_STORE", storeName: "CAT" };
+  atp.omsInstanceKey = instanceKey;
+
+  const ecom = productStore();
+  ecom.ecomStores = [{ productStoreId: "CAT_STORE", storeName: "CAT" }];
+  ecom.currentEComStore = { productStoreId: "CAT_STORE", storeName: "CAT" };
+  ecom.omsInstanceKey = instanceKey;
+
+  useChannelStore().inventoryChannels = [{ facilityId: "OLD_CHANNEL" }];
+  useRuleStore().rules = { list: [{ ruleId: "OLD_RULE" }], total: 1 };
+}
+
+describe("OMS instance scoping of persisted product stores", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mocks.api.mockReset();
+    mocks.omsUrl.value = DEMO_KEY;
+  });
+
+  it("keeps state when the caches are stamped with the connected instance", async () => {
+    seedInstanceState(DEMO_KEY);
+
+    expect(await useUserStore().ensureInstanceScope()).toBe(true);
+
+    expect(useAtpProductStore().currentProductStore.productStoreId).toBe("CAT_STORE");
+    expect(productStore().ecomStores).toHaveLength(1);
+    expect(useChannelStore().inventoryChannels).toHaveLength(1);
+    expect(mocks.api).not.toHaveBeenCalled();
+  });
+
+  it("drops all instance-scoped state when the caches were stamped by another instance", async () => {
+    seedInstanceState(OLD_KEY);
+
+    expect(await useUserStore().ensureInstanceScope()).toBe(false);
+
+    expect(useAtpProductStore().productStores).toHaveLength(0);
+    expect(useAtpProductStore().currentProductStore).toEqual({});
+    expect(productStore().ecomStores).toHaveLength(0);
+    expect(productStore().currentEComStore).toEqual({});
+    expect(useChannelStore().inventoryChannels).toHaveLength(0);
+    expect(useRuleStore().rules.list).toHaveLength(0);
+  });
+
+  it("treats unstamped legacy data as belonging to an unknown instance and drops it", async () => {
+    seedInstanceState("");
+
+    expect(await useUserStore().ensureInstanceScope()).toBe(false);
+    expect(useAtpProductStore().productStores).toHaveLength(0);
+    expect(productStore().currentEComStore).toEqual({});
+  });
+
+  it("leaves empty unstamped state untouched", async () => {
+    expect(await useUserStore().ensureInstanceScope()).toBe(true);
+    expect(mocks.api).not.toHaveBeenCalled();
+  });
+
+  it("keeps state when no instance is connected (no oms cookie), deferring to the login flow", async () => {
+    seedInstanceState(OLD_KEY);
+    mocks.omsUrl.value = "";
+
+    expect(await useUserStore().ensureInstanceScope()).toBe(true);
+    expect(useAtpProductStore().currentProductStore.productStoreId).toBe("CAT_STORE");
+  });
+
+  it("refetches and restamps product stores for the connected instance on hydrate", async () => {
+    seedInstanceState(OLD_KEY);
+    mocks.api.mockImplementation((config: any) => {
+      if (config.url === "admin/user/productStore") {
+        return Promise.resolve({ data: [{ productStoreId: "DEMO_STORE", storeName: "Demo" }] });
+      }
+      return Promise.resolve({ data: [] });
+    });
+
+    expect(await useUserStore().ensureInstanceScope({ refetch: true })).toBe(false);
+
+    const atp = useAtpProductStore();
+    const ecom = productStore();
+    expect(ecom.ecomStores.map((s: any) => s.productStoreId)).toEqual(["DEMO_STORE"]);
+    expect(ecom.currentEComStore.productStoreId).toBe("DEMO_STORE");
+    expect(ecom.omsInstanceKey).toBe(DEMO_KEY);
+    expect(atp.productStores.map((s: any) => s.productStoreId)).toEqual(["DEMO_STORE"]);
+    expect(atp.currentProductStore.productStoreId).toBe("DEMO_STORE");
+    expect(atp.omsInstanceKey).toBe(DEMO_KEY);
+  });
+
+  it("stamps fetched product stores with the connected instance key", async () => {
+    mocks.api.mockResolvedValue({ data: [{ productStoreId: "DEMO_STORE" }] });
+
+    await useAtpProductStore().fetchUserProductStores();
+
+    expect(useAtpProductStore().omsInstanceKey).toBe(getOmsInstanceKey());
+    expect(useAtpProductStore().omsInstanceKey).toBe(DEMO_KEY);
+  });
+
+  it("isInstanceScopeStale only flags caches that hold data for another or unknown instance", () => {
+    expect(isInstanceScopeStale(DEMO_KEY, true)).toBe(false);
+    expect(isInstanceScopeStale(OLD_KEY, true)).toBe(true);
+    expect(isInstanceScopeStale("", true)).toBe(true);
+    expect(isInstanceScopeStale(undefined, true)).toBe(true);
+    expect(isInstanceScopeStale(OLD_KEY, false)).toBe(false);
+    expect(isInstanceScopeStale("", false)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Persisted Pinia state for product stores (`atpProductStore.productStores`/`currentProductStore`, `productStore.ecomStores`/`currentEComStore`) was never invalidated when a user logged into a different OMS instance without an explicit logout — the footer "CAT"-style store selector and every store-scoped page (Inventory, Channels, Facility groups) kept querying a `productStoreId` that doesn't exist on the newly connected instance, rendering empty.
- Each product-store cache is now stamped with the OMS instance it was fetched from (`omsInstanceKey`, derived from the same cookie-backed URL the api layer resolves against).
- `userStore.ensureInstanceScope()` compares the stamp against the connected instance on `postLogin` (before the refetches, so a failed fetch can't leave a foreign store selected) and on app hydrate in `main.ts` (heals state left over from a switch that happened without logging out), clearing all instance-scoped stores and refetching on mismatch. Unstamped legacy data is treated as unknown-instance and cleared too.

## Test plan

- [x] New `tests/omsInstanceScope.test.ts` (8 cases): same-instance state kept untouched, mismatched-instance state cleared, unstamped legacy data cleared, no-connected-instance state deferred to login, hydrate refetch restamps correctly, `isInstanceScopeStale` unit cases.
- [x] Full existing vitest suite of channel/inventory/facility/dashboard specs still passes; the pre-existing failures elsewhere in the suite (sim/circuit/panel specs) are unrelated to this change and present before it too.
- [x] `vue-tsc` type-check delta reviewed — no new error classes introduced beyond the pre-existing baseline.
- [x] Verified live against a real OMS instance (demo-oms/demo-maarg): seeded a stale product-store cache stamped for another instance (and separately, legacy unstamped data matching the reported bug) in the running app, reloaded, and confirmed the cache is cleared and refetched against the connected instance with the selector showing only the connected instance's stores; confirmed a healthy same-instance reload makes zero redundant product-store fetch calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)