### PR TITLE
🧹 Fix creation date consistency for multiple order route filters

### DIFF
--- a/src/components/AddOrderRouteFilterOptions.vue
+++ b/src/components/AddOrderRouteFilterOptions.vue
@@ -116,7 +116,11 @@ function addSortOption(sort: any) {
         orderRoutingId: props.orderRoutingId,
         conditionTypeEnumId: props.conditionTypeEnumId,
         fieldName: sort.enumCode,
-        sequenceNum: Object.keys(routingFilters.value).length && routingFilters.value[Object.keys(routingFilters.value)[Object.keys(routingFilters.value).length - 1]]?.sequenceNum >= 0 ? routingFilters.value[Object.keys(routingFilters.value)[Object.keys(routingFilters.value).length - 1]].sequenceNum + 5 : 0  // added check for `>= 0` as sequenceNum can be 0 which will result in again setting the new seqNum to 0
+        sequenceNum: (() => {
+          const lastFilter: any = Object.values(routingFilters.value).pop()
+          // check for `>= 0` as sequenceNum can be 0 which will result in again setting the new seqNum to 0
+          return lastFilter?.sequenceNum >= 0 ? lastFilter.sequenceNum + 5 : 0
+        })()
       }
     }
   }
@@ -126,9 +130,9 @@ function addSortOption(sort: any) {
 
 function saveSortOptions() {
   const currentTimestamp = DateTime.now().toMillis();
-  Object.keys(routingFilters.value).forEach((key) => {
-    if (!routingFilters.value[key].createdDate) {
-      routingFilters.value[key].createdDate = currentTimestamp;
+  Object.values(routingFilters.value).forEach((filter: any) => {
+    if (!filter.createdDate) {
+      filter.createdDate = currentTimestamp;
     }
   });
 

--- a/src/components/AddOrderRouteFilterOptions.vue
+++ b/src/components/AddOrderRouteFilterOptions.vue
@@ -116,8 +116,7 @@ function addSortOption(sort: any) {
         orderRoutingId: props.orderRoutingId,
         conditionTypeEnumId: props.conditionTypeEnumId,
         fieldName: sort.enumCode,
-        sequenceNum: Object.keys(routingFilters.value).length && routingFilters.value[Object.keys(routingFilters.value)[Object.keys(routingFilters.value).length - 1]]?.sequenceNum >= 0 ? routingFilters.value[Object.keys(routingFilters.value)[Object.keys(routingFilters.value).length - 1]].sequenceNum + 5 : 0,  // added check for `>= 0` as sequenceNum can be 0 which will result in again setting the new seqNum to 0
-        createdDate: DateTime.now().toMillis()  // TODO: need to create createdDate object when clicking save button, as adding it here will have difference between creation time when having multiple filters to create
+        sequenceNum: Object.keys(routingFilters.value).length && routingFilters.value[Object.keys(routingFilters.value)[Object.keys(routingFilters.value).length - 1]]?.sequenceNum >= 0 ? routingFilters.value[Object.keys(routingFilters.value)[Object.keys(routingFilters.value).length - 1]].sequenceNum + 5 : 0  // added check for `>= 0` as sequenceNum can be 0 which will result in again setting the new seqNum to 0
       }
     }
   }
@@ -126,6 +125,13 @@ function addSortOption(sort: any) {
 }
 
 function saveSortOptions() {
+  const currentTimestamp = DateTime.now().toMillis();
+  Object.keys(routingFilters.value).forEach((key) => {
+    if (!routingFilters.value[key].createdDate) {
+      routingFilters.value[key].createdDate = currentTimestamp;
+    }
+  });
+
   closeModal("save");
 }
 


### PR DESCRIPTION
🎯 **What:** Moved `createdDate` assignment to `saveSortOptions` so all newly created filters receive the exact same creation timestamp.
💡 **Why:** Fixes inconsistency where multiple filters added in the same session had slightly varying creation times, and removes an outstanding TODO in the code. Improves maintainability.
✅ **Verification:** Verified the code changes logically using `git diff`. The loop iterates over `routingFilters` and only updates `createdDate` if it doesn't already exist, preserving existing data and applying the fix to new entries.
✨ **Result:** Improved code health and guaranteed consistent timestamps.

---
*PR created automatically by Jules for task [17048503872012303207](https://jules.google.com/task/17048503872012303207) started by @dt2patel*