### PR TITLE
🧹 Remove commented-out code in useProductMaster

### DIFF
--- a/src/composables/useProductMaster.ts
+++ b/src/composables/useProductMaster.ts
@@ -95,63 +95,6 @@ async function clearCache() {
   })
 }
 
-// const primaryId = (product?: any) => {
-//   if (!product) return ''
-//   const pref = useProductStore().getPrimaryId
-
-//   const parsedGoodIds = Array.isArray(product.goodIdentifications) ? product.goodIdentifications.map((goodIdentification: any) => {
-//     if (typeof goodIdentification === 'string' && goodIdentification.includes('/')) {
-//       const [type, value] = goodIdentification.split('/', 2)
-//       return { type: type?.trim(), value: value?.trim() }
-//     }
-//     return goodIdentification
-//   }) : []
-
-//   const resolve = (type: string) => {
-//     if (!type) return ''
-//     if (['SKU', 'SHOPIFY_PROD_SKU'].includes(type))
-//       return parsedGoodIds.find((goodIdentification: any) => goodIdentification.type === 'SKU')?.value || ''
-//     if (type === 'internalName') return product.internalName || ''
-//     if (type === 'productId') return product.productId || ''
-//     if (type === 'parentProductName' || type === 'groupName') return product.parentProductName || ''
-//     if (type === 'title') return product.title || ''
-//     if (type === 'primaryProductCategoryName') return product.primaryProductCategoryName || ''
-//     return parsedGoodIds.find((goodIdentification: any) => goodIdentification.type === type)?.value || ''
-//   }
-
-//   // Try preference, then fallback to SKU or productId
-//   return resolve(pref) || resolve('SKU') || product.productId || ''
-// }
-
-// const secondaryId = (product: any) => {
-//   if (!product) return ''
-//   const pref = useProductStore().getSecondaryId
-
-//   // Parse any flat "TYPE/VALUE" strings (from Solr)
-//   const parsedGoodIds = Array.isArray(product.goodIdentifications) ? product.goodIdentifications.map((goodIdentification: any) => {
-//     if (typeof goodIdentification === 'string' && goodIdentification.includes('/')) {
-//       const [type, value] = goodIdentification.split('/', 2)
-//       return { type: type?.trim(), value: value?.trim() }
-//     }
-//     return goodIdentification
-//   }) : []
-
-//   const resolve = (type: string) => {
-//     if (!type) return ''
-//     if (['SKU', 'SHOPIFY_PROD_SKU'].includes(type))
-//       return parsedGoodIds.find((goodIdentification: any) => goodIdentification.type === 'SKU')?.value || ''
-//     if (type === 'internalName') return product.internalName || ''
-//     if (type === 'productId') return product.productId || ''
-//     if (type === 'parentProductName' || type === 'groupName') return product.parentProductName || ''
-//     if (type === 'title') return product.title || ''
-//     if (type === 'primaryProductCategoryName') return product.primaryProductCategoryName || ''
-//     return parsedGoodIds.find((goodIdentification: any) => goodIdentification.type === type)?.value || ''
-//   }
-
-//   // Try preference, then fallback to productId
-//   return resolve(pref) || product.productId || ''
-// }
-
 export function useProductMaster() {
   return {
     getById,


### PR DESCRIPTION
🎯 **What:** Removed commented-out `primaryId` and `secondaryId` functions from `src/composables/useProductMaster.ts`.
💡 **Why:** Commented-out dead code clutters the file and makes it harder to read. Removing it improves maintainability with zero regression risk.
✅ **Verification:** The only lines removed were comments, ensuring no functional changes to the application.
✨ **Result:** A cleaner, more readable `useProductMaster.ts` file without unnecessary dead code.

---
*PR created automatically by Jules for task [17615852489554364919](https://jules.google.com/task/17615852489554364919) started by @dt2patel*