### PR TITLE
⚡ perf: Optimize fetchRoutingsInformation concurrency

### DIFF
--- a/src/views/BrokeringRunTest.vue
+++ b/src/views/BrokeringRunTest.vue
@@ -200,8 +200,7 @@ async function fetchRoutingGroupInformation() {
 }
 
 async function fetchRoutingsInformation() {
-  // TODO: update logic to fetch the routings in parallel
-  await group.value.routings.forEach(async (routing: any) => {
+  await Promise.all(group.value.routings.map(async (routing: any) => {
     let route = {} as any
     try {
       const resp = await api({
@@ -246,7 +245,7 @@ async function fetchRoutingsInformation() {
     } catch(err) {
       logger.error(err);
     }
-  })
+  }))
 }
 
 async function openRouteDetails(routing: any) {


### PR DESCRIPTION
💡 **What:** Replaced the `forEach(async ...)` loop with `Promise.all(group.value.routings.map(async ...))` in `fetchRoutingsInformation`.
🎯 **Why:** The previous code fired off asynchronous API requests for each routing item but did not await their completion before the `fetchRoutingsInformation` function returned. This caused a race condition where the function appeared to finish but the network requests were still running in the background. Using `Promise.all()` with `map()` ensures all asynchronous calls run concurrently and the function correctly waits for all of them to resolve before proceeding.
📊 **Measured Improvement:** Unable to provide numerical benchmark results due to a missing monorepo workspace configuration (`catalog:` specifiers and `eslint`/`vitest` configuration errors prevented local script execution). However, based on the codebase structure, this clearly fixes a latent race condition (unawaited promises) and successfully implements the `TODO: update logic to fetch the routings in parallel` requirement in a standard, optimal manner by enabling concurrent API dispatch instead of serial/unawaited processing.

---
*PR created automatically by Jules for task [9285621602173744336](https://jules.google.com/task/9285621602173744336) started by @dt2patel*