### PR TITLE
perf: fetch routings in parallel in BrokeringRunTest

### DIFF
--- a/src/views/BrokeringRunTest.vue
+++ b/src/views/BrokeringRunTest.vue
@@ -200,8 +200,7 @@ async function fetchRoutingGroupInformation() {
 }
 
 async function fetchRoutingsInformation() {
-  // TODO: update logic to fetch the routings in parallel
-  await group.value.routings.forEach(async (routing: any) => {
+  await Promise.all(group.value.routings.map(async (routing: any) => {
     let route = {} as any
     try {
       const resp = await api({
@@ -246,7 +245,7 @@ async function fetchRoutingsInformation() {
     } catch(err) {
       logger.error(err);
     }
-  })
+  }))
 }
 
 async function openRouteDetails(routing: any) {


### PR DESCRIPTION
Replaced `group.value.routings.forEach(async ...)` with `await Promise.all(group.value.routings.map(async ...))` in `src/views/BrokeringRunTest.vue` to fetch routings in parallel and ensure execution waits for all requests to finish.

---
*PR created automatically by Jules for task [13185536231431435217](https://jules.google.com/task/13185536231431435217) started by @dt2patel*