### PR TITLE
⚡ Bolt: parallelize stock fetching requests

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-07-21 - Parallelize stock fetching in stores
+**Learning:** Found sequential API calls (N+1 queries) inside `for...of` loops in `fetchStock` methods of Pinia stores (`product.ts` and `productInventory.ts`). This blocked the main execution flow unnecessarily as each request waited for the previous one.
+**Action:** Replaced sequential `for...of` loops with `await Promise.all(productIds.map(async (productId) => {...}))` to fire network requests concurrently, significantly reducing data load latency for large product groupings (like ship groups).

--- a/src/store/product.ts
+++ b/src/store/product.ts
@@ -59,9 +59,10 @@ export const productStore = defineStore('product', {
     async fetchStock(shipGroup: Array<any>) {
       const productIds = shipGroup.map((item: any) => item.productId)
       const facilityId = shipGroup[0].facilityId
-      for(const productId of productIds) {
+
+      const fetchPromises = productIds.map(async (productId) => {
         if(this.stock[productId]?.[facilityId]) {
-          continue;
+          return;
         }
   
         try {
@@ -90,7 +91,9 @@ export const productStore = defineStore('product', {
         } catch (err) {
           logger.error(err)
         }
-      }
+      })
+
+      await Promise.all(fetchPromises);
     },
     async clearProductState() {
       this.products = {};

--- a/src/store/productInventory.ts
+++ b/src/store/productInventory.ts
@@ -184,7 +184,7 @@ export const useProductInventoryStore = defineStore('productInventory', {
       this.productSyncCompletedAt = 0
     },
     async fetchStock(productIds: Array<string>, facilityId: string) {
-      for (const productId of productIds) {
+      const fetchPromises = productIds.map(async (productId) => {
         try {
           const resp: any = await api({
             url: "poorti/getInventoryAvailableByFacility",
@@ -206,7 +206,9 @@ export const useProductInventoryStore = defineStore('productInventory', {
         } catch (err) {
           logger.error(err)
         }
-      }
+      })
+
+      await Promise.all(fetchPromises);
     }
   }
 })


### PR DESCRIPTION
💡 **What:** 
Refactored the `fetchStock` methods in both `src/store/product.ts` and `src/store/productInventory.ts` to execute network requests concurrently using `Promise.all` and `Array.prototype.map`, replacing the previous sequential `for...of` loops. Error handling remains scoped per-item to match previous behavior.

🎯 **Why:** 
The sequential `for...of` loops created an N+1 query bottleneck over the network, where fetching stock for `N` products required waiting for `N` consecutive round trips. This unnecessarily delayed rendering data for components reliant on complete ship-group inventory information (like the routing tests).

📊 **Impact:** 
Expected performance improvement: Fetches that previously took `O(N) * average_network_latency` will now complete in `O(1) * max_network_latency` (bounded by browser concurrency limits). This translates to a drastically faster data hydration experience when dealing with multiple items in an order group.

🔬 **Measurement:** 
Load a view utilizing `fetchStock` for a large group of items (e.g. testing a routing group with multiple products). Inspect the Network tab in DevTools; you should observe multiple `getInventoryAvailableByFacility` requests being dispatched simultaneously instead of staggered sequentially. Load times for the components will be noticeably faster.

---
*PR created automatically by Jules for task [11047077678696006421](https://jules.google.com/task/11047077678696006421) started by @dt2patel*