### PR TITLE
🧹 [code health improvement] Remove commented out unused Vue template elements

### DIFF
--- a/src/views/InventoryChannels.vue
+++ b/src/views/InventoryChannels.vue
@@ -76,10 +76,6 @@
     
                 <div class="actions">
                   <ion-button fill="clear" @click="openEditGroupModal(channel)">{{ translate("Edit group") }}</ion-button>
-                  <!-- Functionality is not defined for this button hence commented it for now. -->
-                  <!-- <ion-button color="medium" fill="clear" slot="end">
-                    <ion-icon :icon="ellipsisVerticalOutline" slot="icon-only"/>
-                  </ion-button> -->
                 </div>
               </ion-list>
             </ion-card>


### PR DESCRIPTION
🎯 **What:** Removed commented out unused Vue template elements in `src/views/InventoryChannels.vue`.
💡 **Why:** Removing dead commented-out HTML templates is low risk and improves readability.
✅ **Verification:** Ran `npm run lint` and `npm run test:unit -- --run` to ensure no functionality is broken and there are no regressions.
✨ **Result:** Improved readability by removing dead code.

---
*PR created automatically by Jules for task [12577418299804573106](https://jules.google.com/task/12577418299804573106) started by @dt2patel*