### PR TITLE
⚡ Bolt: Parallelize enum fetching in utilStore

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2026-07-21 - Parallelize stock fetching in stores
 **Learning:** Found sequential API calls (N+1 queries) inside `for...of` loops in `fetchStock` methods of Pinia stores (`product.ts` and `productInventory.ts`). This blocked the main execution flow unnecessarily as each request waited for the previous one.
 **Action:** Replaced sequential `for...of` loops with `await Promise.all(productIds.map(async (productId) => {...}))` to fire network requests concurrently, significantly reducing data load latency for large product groupings (like ship groups).
+## 2026-07-25 - Parallelize enum fetching in Pinia stores
+**Learning:** Found sequential API calls inside `for...of` loops in `fetchRoutingEditorEnums` of `src/store/utilStore.ts`. The loop awaited `fetchEnums({ enumTypeId })` one by one because the original `fetchEnums` logic snapshotted `this.enums` at the start of the function and saved it at the end, causing a race condition if run in parallel.
+**Action:** Changed the global state snapshot to happen immediately before merging the new data inside the response handling block, modifying `this.enums` atomically. This allowed the sequential `for...of` in `fetchRoutingEditorEnums` to be upgraded to a `Promise.all`, reducing network waterfalls for initial configuration loading.

--- a/src/store/utilStore.ts
+++ b/src/store/utilStore.ts
@@ -42,12 +42,12 @@ export const useUtilStore = defineStore('util', {
     // The migrated admin endpoint is scoped by enumTypeId. Query the editor's families explicitly
     // and sequentially because fetchEnums merges into the current store snapshot after each request.
     async fetchRoutingEditorEnums() {
-      for (const enumTypeId of ROUTING_EDITOR_ENUM_TYPE_IDS) {
-        await this.fetchEnums({ enumTypeId });
-      }
+      // ⚡ Bolt: Parallelize enum fetching to reduce network waterfall
+      await Promise.all(
+        ROUTING_EDITOR_ENUM_TYPE_IDS.map(enumTypeId => this.fetchEnums({ enumTypeId }))
+      );
     },
     async fetchEnums(payload: any) {
-      let enums = { ...this.enums };
       let pageIndex = 0;
       const pageSize = 500;
   
@@ -100,17 +100,23 @@ export const useUtilStore = defineStore('util', {
                 "description": "Facility group"
               } as any
             }
-            enums = {
-              ...enums,
-              ...respEnums
+            // ⚡ Bolt: Safely merge at the type level directly into this.enums
+            // inside the response handler to prevent race conditions during parallel requests
+            const updatedEnums = { ...this.enums };
+            for (const typeId in respEnums) {
+              updatedEnums[typeId] = {
+                ...(updatedEnums[typeId] || {}),
+                ...respEnums[typeId]
+              };
             }
+            this.enums = updatedEnums;
           }
           pageIndex++;
         } while(resp.data.length == pageSize)
       } catch(err) {
         logger.error(err)
       }
-      this.enums = enums;
+
     },
     async fetchOmsEnums(payload: any) {
       let enums = { ...this.enums };


### PR DESCRIPTION
💡 **What:**
Replaced a sequential `for...of` loop in `fetchRoutingEditorEnums` with `Promise.all` to fetch configuration enums concurrently. Also modified `fetchEnums` to safely merge updates directly into the store's global state (`this.enums`) at the type level inside the response handler block, rather than maintaining a function-scope snapshot that caused race conditions.

🎯 **Why:** 
Previously, the editor configuration enums were fetched one by one because the underlying `fetchEnums` action was susceptible to race conditions (it snapshotted the state before making the network request, then merged and saved it, overwriting other in-flight updates). This sequential fetching created an unnecessary network waterfall that delayed the initialization of the routing rules editor.

📊 **Impact:** 
Eliminates a sequential network waterfall consisting of 5 consecutive API calls, significantly reducing load time for the editor views by allowing these queries to run concurrently.

🔬 **Measurement:** 
1. Open the network tab in browser devtools.
2. Navigate to a route that loads the order routing editor (which triggers `fetchRoutingEditorEnums`).
3. Observe that the `/admin/enums` calls for the different enum type IDs are now dispatched in parallel rather than sequentially, reducing total request latency.

---
*PR created automatically by Jules for task [10313912425221578762](https://jules.google.com/task/10313912425221578762) started by @dt2patel*