### PR TITLE
⚡ Bolt: parallelize enum fetching in util store

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2026-07-21 - Parallelize stock fetching in stores
 **Learning:** Found sequential API calls (N+1 queries) inside `for...of` loops in `fetchStock` methods of Pinia stores (`product.ts` and `productInventory.ts`). This blocked the main execution flow unnecessarily as each request waited for the previous one.
 **Action:** Replaced sequential `for...of` loops with `await Promise.all(productIds.map(async (productId) => {...}))` to fire network requests concurrently, significantly reducing data load latency for large product groupings (like ship groups).
+## 2026-07-26 - Parallelize routing enum loading in util store
+**Learning:** Found sequential API calls inside `for...of` loops in `fetchRoutingEditorEnums` of Pinia stores (`utilStore.ts`). Additionally, discovered that concurrently fetching enums caused race conditions because the `fetchEnums` action took a snapshot of `this.enums` before the API call, rather than merging into the live state after.
+**Action:** Replaced sequential `for...of` loops with `await Promise.all(typeIds.map(id => this.fetchEnums({id})))`. Fixed the race condition in `fetchEnums` by removing the initial snapshot and explicitly merging the fetched data into the live `this.enums` object at the end of the action.

--- a/src/store/utilStore.ts
+++ b/src/store/utilStore.ts
@@ -39,15 +39,15 @@ export const useUtilStore = defineStore('util', {
     }
   },
   actions: {
-    // The migrated admin endpoint is scoped by enumTypeId. Query the editor's families explicitly
-    // and sequentially because fetchEnums merges into the current store snapshot after each request.
+    // The migrated admin endpoint is scoped by enumTypeId. Query the editor's families explicitly.
+    // fetchEnums is safe to call concurrently as it merges into the live store snapshot after each request.
     async fetchRoutingEditorEnums() {
-      for (const enumTypeId of ROUTING_EDITOR_ENUM_TYPE_IDS) {
-        await this.fetchEnums({ enumTypeId });
-      }
+      await Promise.all(
+        ROUTING_EDITOR_ENUM_TYPE_IDS.map((enumTypeId) => this.fetchEnums({ enumTypeId }))
+      );
     },
     async fetchEnums(payload: any) {
-      let enums = { ...this.enums };
+      let enums = {} as any;
       let pageIndex = 0;
       const pageSize = 500;
   
@@ -110,10 +110,10 @@ export const useUtilStore = defineStore('util', {
       } catch(err) {
         logger.error(err)
       }
-      this.enums = enums;
+      this.enums = { ...this.enums, ...enums };
     },
     async fetchOmsEnums(payload: any) {
-      let enums = { ...this.enums };
+      let enums = {} as any;
   
       try {
         const resp = await api({
@@ -140,7 +140,7 @@ export const useUtilStore = defineStore('util', {
       } catch(err) {
         logger.error(err)
       }
-      this.enums = enums;
+      this.enums = { ...this.enums, ...enums };
     },
 
     async fetchCategories() {


### PR DESCRIPTION
💡 **What:**
Replaced the sequential `for...of` loop in `fetchRoutingEditorEnums` with a concurrent `Promise.all` mapping. Additionally, refactored state assignment in `fetchEnums` and `fetchOmsEnums` to merge data directly into the live `this.enums` state *after* the network request completes, rather than mutating a snapshot captured before the network request.

🎯 **Why:**
The application was making 5 sequential network requests to load required editor enums on startup, creating an unnecessary network waterfall that blocked execution. Attempting to parallelize these requests naively caused a race condition where the last-resolving request would overwrite the state of the earlier-resolving requests due to stale closures. This patch safely parallelizes the requests and fixes the underlying race condition.

📊 **Impact:**
Reduces the enum loading time from the sum of 5 sequential API requests down to the latency of a single (the slowest) API request. This significantly accelerates the time-to-interactive for the routing editor.

🔬 **Measurement:**
Open the network tab when navigating to the routing editor. You should see all 5 requests to `admin/enums` trigger simultaneously rather than cascading sequentially. Verify that the routing editor still correctly renders all filter/sort dropdowns using the loaded enums.

---
*PR created automatically by Jules for task [6419755223225285071](https://jules.google.com/task/6419755223225285071) started by @dt2patel*