### PR TITLE
⚡ Bolt: Parallelize API calls in utilStore for faster enum loading

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2026-07-21 - Parallelize stock fetching in stores
 **Learning:** Found sequential API calls (N+1 queries) inside `for...of` loops in `fetchStock` methods of Pinia stores (`product.ts` and `productInventory.ts`). This blocked the main execution flow unnecessarily as each request waited for the previous one.
 **Action:** Replaced sequential `for...of` loops with `await Promise.all(productIds.map(async (productId) => {...}))` to fire network requests concurrently, significantly reducing data load latency for large product groupings (like ship groups).
+## 2026-07-27 - Safe state merging for concurrent Pinia calls
+**Learning:** Found sequential API calls inside `for...of` loops in `fetchRoutingEditorEnums` (`utilStore.ts`). These were deliberately sequential because `fetchEnums` previously read a snapshot of the state at the start and completely overwrote it at the end, which would cause concurrent `Promise.all` calls to clobber each other's additions in a classic race condition.
+**Action:** Replaced sequential `for...of` with `await Promise.all(...)` and fixed the race condition by rewriting the state mutation in `fetchEnums` to merge data directly against the *latest* state snapshot at the exact moment the async request finishes.

--- a/src/store/utilStore.ts
+++ b/src/store/utilStore.ts
@@ -40,11 +40,11 @@ export const useUtilStore = defineStore('util', {
   },
   actions: {
     // The migrated admin endpoint is scoped by enumTypeId. Query the editor's families explicitly
-    // and sequentially because fetchEnums merges into the current store snapshot after each request.
+    // and concurrently to improve loading performance.
     async fetchRoutingEditorEnums() {
-      for (const enumTypeId of ROUTING_EDITOR_ENUM_TYPE_IDS) {
-        await this.fetchEnums({ enumTypeId });
-      }
+      await Promise.all(
+        ROUTING_EDITOR_ENUM_TYPE_IDS.map((enumTypeId) => this.fetchEnums({ enumTypeId }))
+      );
     },
     async fetchEnums(payload: any) {
       let enums = { ...this.enums };
@@ -100,9 +100,12 @@ export const useUtilStore = defineStore('util', {
                 "description": "Facility group"
               } as any
             }
-            enums = {
-              ...enums,
-              ...respEnums
+            // Deep merge to avoid race conditions when fetched concurrently
+            for (const [enumTypeId, enumData] of Object.entries(respEnums)) {
+              enums[enumTypeId as string] = {
+                ...(enums[enumTypeId as string] || {}),
+                ...(enumData as any)
+              }
             }
           }
           pageIndex++;
@@ -110,7 +113,15 @@ export const useUtilStore = defineStore('util', {
       } catch(err) {
         logger.error(err)
       }
-      this.enums = enums;
+      // Important: merge with latest state in case of concurrent updates
+      const latestEnums = { ...this.enums };
+      for (const [enumTypeId, enumData] of Object.entries(enums)) {
+        latestEnums[enumTypeId] = {
+          ...(latestEnums[enumTypeId] || {}),
+          ...(enumData as any)
+        }
+      }
+      this.enums = latestEnums;
     },
     async fetchOmsEnums(payload: any) {
       let enums = { ...this.enums };
@@ -140,7 +151,15 @@ export const useUtilStore = defineStore('util', {
       } catch(err) {
         logger.error(err)
       }
-      this.enums = enums;
+      // Important: merge with latest state in case of concurrent updates
+      const latestEnums = { ...this.enums };
+      for (const [enumTypeId, enumData] of Object.entries(enums)) {
+        latestEnums[enumTypeId] = {
+          ...(latestEnums[enumTypeId] || {}),
+          ...(enumData as any)
+        }
+      }
+      this.enums = latestEnums;
     },
 
     async fetchCategories() {


### PR DESCRIPTION
💡 **What:** 
Optimized `fetchRoutingEditorEnums` in `src/store/utilStore.ts` to execute network requests concurrently.

🎯 **Why:** 
The method was performing N network requests sequentially (using a `for...await` loop), leading to a "waterfall" network pattern that unnecessarily blocks the application while waiting on independent backend queries. This was a direct result of how `fetchEnums` mutated state, as running it concurrently would historically overwrite earlier completions with a stale state snapshot (a race condition). 

📊 **Impact:** 
Replaces sequential loading with `Promise.all`. The total time spent fetching routing editor enums decreases from `O(N * Latency)` to roughly `O(Latency)` (where `N` is the length of `ROUTING_EDITOR_ENUM_TYPE_IDS`), accelerating UI rendering and data readiness.

🔬 **Measurement:** 
Open the browser's Network tab and observe the `/admin/enums` calls initiated by `fetchRoutingEditorEnums`. They should now be dispatched concurrently rather than waiting for each previous request to finish. The application state for enums must be correctly merged without any dropped values.

---
*PR created automatically by Jules for task [2991203122100276465](https://jules.google.com/task/2991203122100276465) started by @dt2patel*