### PR TITLE
⚡ Bolt: Parallelize enum fetching in utilStore

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2026-07-21 - Parallelize stock fetching in stores
 **Learning:** Found sequential API calls (N+1 queries) inside `for...of` loops in `fetchStock` methods of Pinia stores (`product.ts` and `productInventory.ts`). This blocked the main execution flow unnecessarily as each request waited for the previous one.
 **Action:** Replaced sequential `for...of` loops with `await Promise.all(productIds.map(async (productId) => {...}))` to fire network requests concurrently, significantly reducing data load latency for large product groupings (like ship groups).
+
+## 2026-07-28 - Parallelize utilStore enum fetching
+**Learning:** Found sequential API calls inside a `for...of` loop in `fetchRoutingEditorEnums`. They were intentionally sequential due to a race condition caused by stale state snapshotting during the merge in `fetchEnums`. By refactoring the update pattern to not use snapshots (`this.state = { ...this.state, ...newData }`), we successfully removed the bottleneck.
+**Action:** Refactored `fetchEnums` to safely merge state immediately and replaced the `for...of` loop in `fetchRoutingEditorEnums` with `await Promise.all()` to fire network requests concurrently, improving initialization latency.

--- a/src/store/utilStore.ts
+++ b/src/store/utilStore.ts
@@ -39,15 +39,14 @@ export const useUtilStore = defineStore('util', {
     }
   },
   actions: {
-    // The migrated admin endpoint is scoped by enumTypeId. Query the editor's families explicitly
-    // and sequentially because fetchEnums merges into the current store snapshot after each request.
+    // The migrated admin endpoint is scoped by enumTypeId. Query the editor's families explicitly.
+    // fetchEnums is safe for concurrent calls, so we can fetch all families in parallel.
     async fetchRoutingEditorEnums() {
-      for (const enumTypeId of ROUTING_EDITOR_ENUM_TYPE_IDS) {
-        await this.fetchEnums({ enumTypeId });
-      }
+      await Promise.all(
+        ROUTING_EDITOR_ENUM_TYPE_IDS.map(enumTypeId => this.fetchEnums({ enumTypeId }))
+      );
     },
     async fetchEnums(payload: any) {
-      let enums = { ...this.enums };
       let pageIndex = 0;
       const pageSize = 500;
   
@@ -100,21 +99,24 @@ export const useUtilStore = defineStore('util', {
                 "description": "Facility group"
               } as any
             }
-            enums = {
-              ...enums,
-              ...respEnums
+
+            // Deep merge needed since values are nested by enumTypeId
+            const newEnums = { ...this.enums }
+            for (const typeId of Object.keys(respEnums)) {
+              newEnums[typeId] = {
+                ...(newEnums[typeId] || {}),
+                ...respEnums[typeId]
+              }
             }
+            this.enums = newEnums
           }
           pageIndex++;
         } while(resp.data.length == pageSize)
       } catch(err) {
         logger.error(err)
       }
-      this.enums = enums;
     },
     async fetchOmsEnums(payload: any) {
-      let enums = { ...this.enums };
-  
       try {
         const resp = await api({
           url: "admin/enums",
@@ -126,7 +128,7 @@ export const useUtilStore = defineStore('util', {
         });
   
         if(!commonUtil.hasError(resp) && resp.data.length) {
-          enums = resp.data.reduce((enumerations: any, data: EnumerationAndType) => {
+          const respEnums = resp.data.reduce((enumerations: any, data: EnumerationAndType) => {
             if(enumerations[data.enumTypeId]) {
               enumerations[data.enumTypeId][data.enumId] = data
             } else {
@@ -135,12 +137,21 @@ export const useUtilStore = defineStore('util', {
               }
             }
             return enumerations
-          }, enums)
+          }, {})
+
+          // Deep merge needed since values are nested by enumTypeId
+          const newEnums = { ...this.enums }
+          for (const typeId of Object.keys(respEnums)) {
+            newEnums[typeId] = {
+              ...(newEnums[typeId] || {}),
+              ...respEnums[typeId]
+            }
+          }
+          this.enums = newEnums
         }
       } catch(err) {
         logger.error(err)
       }
-      this.enums = enums;
     },
 
     async fetchCategories() {


### PR DESCRIPTION
💡 What: Refactored `fetchEnums` and `fetchOmsEnums` to safely merge state immediately after API calls rather than relying on stale state snapshots, and updated `fetchRoutingEditorEnums` to fetch all enum types in parallel instead of sequentially.
🎯 Why: `fetchRoutingEditorEnums` previously iterated through `ROUTING_EDITOR_ENUM_TYPE_IDS` using a `for...of` loop, awaiting each response sequentially. This was necessary due to a race condition where concurrent calls to `fetchEnums` would overwrite each other's results due to capturing a snapshot of `this.enums` before the network request.
📊 Impact: Expected reduction in network latency proportional to `N-1` requests, where `N` is the number of enum types (currently 5).
🔬 Measurement: Verify loading time of the editor initialization logic where `fetchRoutingEditorEnums` is called. It should be noticeably faster without causing data loss.

---
*PR created automatically by Jules for task [16475631686741431265](https://jules.google.com/task/16475631686741431265) started by @dt2patel*