### PR TITLE
feat: migrate rule action field names to native camelCase

### DIFF
--- a/src/components/RuleItem.vue
+++ b/src/components/RuleItem.vue
@@ -189,7 +189,7 @@ async function editThreshold() {
           rule.ruleActions = [{
             "ruleId": props.rule.ruleId,
             "actionTypeEnumId": "ATP_SAFETY_STOCK",
-            "fieldName": "facility-safety-stock",
+            "fieldName": "minimumStock",
             "fieldValue": data.threshold
           }]
         } else {
@@ -251,7 +251,7 @@ async function editSafetyStock() {
           rule.ruleActions = [{
             "ruleId": props.rule.ruleId,
             "actionTypeEnumId": "ATP_SAFETY_STOCK",
-            "fieldName": "facility-safety-stock",
+            "fieldName": "minimumStock",
             "fieldValue": data.safetyStock
           }]
         } else {

--- a/src/utils/ruleUtil.ts
+++ b/src/utils/ruleUtil.ts
@@ -69,9 +69,9 @@ const generateRuleActions = (ruleId: string, actionTypeEnumId: string, actionVal
 
   let condition;
   if (actionTypeEnumId === "ATP_THRESHOLD" || actionTypeEnumId === "ATP_SAFETY_STOCK") {
-    condition = [{ ruleId, actionTypeEnumId, "fieldName": "facility-safety-stock", "fieldValue": actionValue ? actionValue : 0 }]
+    condition = [{ ruleId, actionTypeEnumId, "fieldName": "minimumStock", "fieldValue": actionValue ? actionValue : 0 }]
   } else {
-    condition = [{ ruleId, actionTypeEnumId, "fieldName": actionTypeEnumId === "ATP_ALLOW_PICKUP" ? "allow-pickup" : "allow-brokering", "fieldValue": actionValue ? "Y" : "N" }]
+    condition = [{ ruleId, actionTypeEnumId, "fieldName": actionTypeEnumId === "ATP_ALLOW_PICKUP" ? "allowPickup" : "allowBrokering", "fieldValue": actionValue ? "Y" : "N" }]
   }
   return condition
 }


### PR DESCRIPTION
## Description

This PR migrates the rule action `fieldName` identifiers to use the native entity property names expected by the Moqui backend DataManager. This eliminates the need for complex, legacy column-mapping logic in the backend.

### Changes Made
* `facility-safety-stock` ➔ `minimumStock`
* `allow-brokering` ➔ `allowBrokering`
* `allow-pickup` ➔ `allowPickup`

## How to Test
1. Check out `feature/update-rule-action-fields`.
2. Create a new Threshold, Safety Stock, Shipping, or Store Pickup rule in the UI.
3. Verify the generated rule payload correctly saves with the new camelCase property names instead of the old legacy names.
