### PR TITLE
Improved: Centralized app permissions into a single authorization actions file.

### DIFF
--- a/src/authorization/actions.ts
+++ b/src/authorization/actions.ts
@@ -1,0 +1,15 @@
+/**
+ * App actions mapped to the server permissions they require.
+ *
+ * Views, components and routes should always refer to an action from this file instead of
+ * hardcoding a server permission, so that a permission change is a one line change here.
+ *
+ * The value is the permission expression evaluated by `hasPermission` of the user store.
+ * It supports the `OR` and `AND` operators, and an empty value means the action is allowed
+ * for every logged in user.
+ */
+export default {
+  APP_TEST_DRIVE_VIEW: "ROUTING_TEST_DRIVE_VIEW",
+  APP_PRODUCT_IDENTIFIER_UPDATE: "COMMON_ADMIN",
+  APP_PWA_STANDALONE_ACCESS: "COMMON_ADMIN"
+} as const satisfies Record<string, string>

--- a/src/components/DxpProductIdentifier.vue
+++ b/src/components/DxpProductIdentifier.vue
@@ -8,12 +8,12 @@
       {{ translate("Choosing a product identifier allows you to view products with your preferred identifiers.") }}
     </ion-card-content>
 
-    <ion-item :disabled="!userStore.hasPermission('COMMON_ADMIN')">
+    <ion-item :disabled="!userStore.hasPermission(Actions.APP_PRODUCT_IDENTIFIER_UPDATE)">
       <ion-select :label="translate('Primary')" interface="popover" :placeholder="translate('primary identifier')" :value="productIdentificationPref.primaryId" @ionChange="setProductIdentificationPref($event.detail.value, 'primaryId')">
         <ion-select-option v-for="identification in productIdentificationOptions" :key="identification.goodIdentificationTypeId" :value="identification.goodIdentificationTypeId">{{ translate(identification.description || identification.goodIdentificationTypeId) }}</ion-select-option>
       </ion-select>
     </ion-item>
-    <ion-item lines="none" :disabled="!userStore.hasPermission('COMMON_ADMIN')">
+    <ion-item lines="none" :disabled="!userStore.hasPermission(Actions.APP_PRODUCT_IDENTIFIER_UPDATE)">
       <ion-select :label="translate('Secondary')" interface="popover" :placeholder="translate('secondary identifier')" :value="productIdentificationPref.secondaryId" @ionChange="setProductIdentificationPref($event.detail.value, 'secondaryId')">
         <ion-select-option v-for="identification in productIdentificationOptions" :key="identification.goodIdentificationTypeId" :value="identification.goodIdentificationTypeId">{{ translate(identification.description || identification.goodIdentificationTypeId) }}</ion-select-option>
         <ion-select-option value="">{{ translate("None") }}</ion-select-option>
@@ -47,6 +47,7 @@ import { shuffleOutline } from "ionicons/icons";
 import { productStore } from "@/store/productStore";
 import { useUserStore } from "@/store/userStore";
 import { getPrimaryProductIdentifier, getSecondaryProductIdentifier } from "@/utils/productIdentifier";
+import Actions from "@/authorization/actions";
 
 const store = productStore();
 const userStore = useUserStore();

--- a/src/components/circuit/RoutingGroupEditor.vue
+++ b/src/components/circuit/RoutingGroupEditor.vue
@@ -112,7 +112,7 @@
         </ion-item>
       </ion-card>
 
-      <ion-card v-if="!isSandbox && testDriveEnabled && userStore.hasPermission('ROUTING_TEST_DRIVE_VIEW')">
+      <ion-card v-if="!isSandbox && testDriveEnabled && userStore.hasPermission(Actions.APP_TEST_DRIVE_VIEW)">
         <ion-card-header>
           <ion-card-subtitle>{{ translate("Test drive") }}</ion-card-subtitle>
         </ion-card-header>
@@ -804,6 +804,7 @@ import {
   restoreVariationToBaseline,
   type VariationDiffTarget
 } from "@/utils/variationConfigDiff";
+import Actions from "@/authorization/actions";
 
 const props = defineProps({
   routingGroupId: {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -17,6 +17,7 @@ import {
   storefrontOutline
 } from "ionicons/icons";
 import { RouteRecordRaw } from "vue-router";
+import Actions from "@/authorization/actions";
 
 
 declare module "vue-router" {
@@ -65,7 +66,7 @@ const routingGroupGuard = (to: any, from: any, next: any) =>
 const simulateGuard = (to: any, from: any, next: any) =>
   isFeatureEnabled("simulation") ? authGuard(to, from, next) : next("/order-routing");
 
-export const ROUTING_TEST_DRIVE_PERMISSION_ID = "ROUTING_TEST_DRIVE_VIEW";
+export const ROUTING_TEST_DRIVE_PERMISSION_ID = Actions.APP_TEST_DRIVE_VIEW;
 
 export function routingGroupRequiresSaveBeforeTest(routingGroupId: string): boolean {
   const store = orderRoutingStore();

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -23,7 +23,7 @@
             </ion-card-header>
           </ion-item>
           <ion-button color="danger" @click="logout()">{{ translate("Logout") }}</ion-button>
-          <ion-button :standalone-hidden="!userStore.hasPermission('COMMON_ADMIN')" fill="outline" @click="goToLaunchpad()">
+          <ion-button :standalone-hidden="!userStore.hasPermission(Actions.APP_PWA_STANDALONE_ACCESS)" fill="outline" @click="goToLaunchpad()">
             {{ translate("Go to Launchpad") }}
             <ion-icon slot="end" :icon="openOutline" />
           </ion-button>
@@ -131,6 +131,7 @@ import { useAuth } from "@common/composables/useAuth";
 import DxpAppVersionInfo from "@/components/DxpAppVersionInfo.vue";
 import DxpProductIdentifier from "@/components/DxpProductIdentifier.vue";
 import { usePreferencesStore } from "@/store/preferences";
+import Actions from "@/authorization/actions";
 
 const userStore = useUserStore()
 const preferencesStore = usePreferencesStore()


### PR DESCRIPTION
Introduces `src/authorization/actions.ts`, a single map of app action to the server permission it requires. Views, components and routes now pass an action instead of a hardcoded permission string, so a permission change is a one line change in that file.

Action names are taken from the pre-migration `src/authorization/Rules.ts` wherever a rule matched, so they stay familiar. The value is the permission expression itself, so the user store's `hasPermission` is unchanged.

No behaviour change: every call site resolves to the exact same permission expression as before.