### PR TITLE
Fix: Use inventory item variances resource for variance audit lookup (#532)

### DIFF
--- a/src/composables/useInventory.ts
+++ b/src/composables/useInventory.ts
@@ -143,9 +143,9 @@ export function useInventory() {
     let result: VarianceAudit | null = null
     try {
       const resp = await api({
-        url: "/oms/inventoryItemVariances",
+        url: `/oms/inventoryItem/${inventoryItemId}/variances`,
         method: "GET",
-        params: { inventoryItemId, physicalInventoryId, pageSize: 1 }
+        params: { physicalInventoryId, pageSize: 1 }
       }) as any
 
       const row = Array.isArray(resp?.data) ? resp.data[0] : (resp?.data?.list?.[0] ?? null)


### PR DESCRIPTION
## Related Issue

Closes #532

## Description

This PR fixes the inventory variance audit lookup on the Inventory Detail page.

Previously, the application attempted to fetch variance details using the `/oms/inventoryItemVariances` endpoint, which is not a valid OMS REST resource and resulted in a `404 Not Found` response. Consequently, variance details could not be displayed when expanding an inventory adjustment.

This change updates the request to use the existing nested Inventory Item variances resource.

## Changes Made

- Updated `fetchVarianceAudit` in `src/composables/useInventory.ts`.
- Replaced:
  - `GET /oms/inventoryItemVariances`
- With:
  - `GET /oms/inventoryItem/{inventoryItemId}/variances`
- Removed `inventoryItemId` from the query parameters since it is now passed as a path parameter.
- Continued passing `physicalInventoryId` and `pageSize` as query parameters.

## Verification

- Verified expanding an inventory adjustment no longer results in a `404 Not Found` response.
- Verified variance details are successfully retrieved from the Inventory Item variances resource.
- Verified filtering using `physicalInventoryId` continues to work as expected.