### PR TITLE
Fix: align CreateGroupModal ID input with standard Ionic behavior (#534)

### DIFF
--- a/src/components/CreateGroupModal.vue
+++ b/src/components/CreateGroupModal.vue
@@ -17,8 +17,8 @@
           <div slot="label">{{ translate("Name") }} <ion-text color="danger">*</ion-text></div>
         </ion-input>
       </ion-item>
-      <ion-item lines="none">
-        <ion-input :label="translate('ID')" labelPlacement="floating" ref="facilityGroupId" v-model="formData.facilityGroupId" @ionInput="validateFacilityGroupId" @ionBlur="markFacilityGroupIdTouched" :error-text="translate('Internal ID cannot be more than 20 characters.')" />
+      <ion-item>
+        <ion-input :label="translate('ID')" labelPlacement="floating" v-model="formData.facilityGroupId" :maxlength="20" />
       </ion-item>
       <ion-item>
         <ion-textarea :label="translate('Description')" v-model="formData.description" labelPlacement="floating" :maxlength="255" />
@@ -61,7 +61,6 @@ const formData = ref({
   description: "",
 }) as any;
 const selectedConfigFacilityId = ref("new");
-const facilityGroupId = ref("") as any;
 
 const currentProductStore = computed(() => productStore.getCurrentProductStore)
 const configFacilities = computed(() => productStore.getConfigFacilities)
@@ -145,21 +144,5 @@ async function createGroup() {
 
 function setFacilityGroupId(event: any) {
   formData.value.facilityGroupId = commonUtil.generateInternalId(event.target.value)
-}
-
-function validateFacilityGroupId(event: any) {
-  const value = event.target.value;
-  facilityGroupId.value.$el.classList.remove('ion-valid');
-  facilityGroupId.value.$el.classList.remove('ion-invalid');
-
-  if (value === '') return;
-
-  formData.value.facilityGroupId.length <= 20
-    ? facilityGroupId.value.$el.classList.add('ion-valid')
-    : facilityGroupId.value.$el.classList.add('ion-invalid');
-}
-
-function markFacilityGroupIdTouched() {
-  facilityGroupId.value.$el.classList.add('ion-touched');
 }
 </script>


### PR DESCRIPTION
## Related Issue

Closes #534

## Summary

Fixes inconsistent behavior of the **ID** field in the **Create Channel Group** modal by aligning it with the standard Ionic input implementation used by the **Name** and **Description** fields.

## Root Cause

The ID field used a custom validation implementation that differed from the other inputs:

- The input was wrapped in `<ion-item lines="none">`, preventing the default underline from being displayed in the unfocused state.
- Custom `@ionInput` and `@ionBlur` handlers manually applied Ionic validation classes (`ion-valid`, `ion-invalid`, and `ion-touched`).
- Because Ionic applies different styling to inputs marked as `ion-valid`, the ID field displayed a different focus highlight and interaction compared to the other fields.

## Changes Made

- Removed `lines="none"` from the ID field container to restore the default Ionic underline.
- Removed custom validation handlers and manual DOM class manipulation.
- Replaced the custom length validation with the native `maxlength="20"` attribute on `ion-input`.
- Aligned the ID field implementation with the existing Name and Description fields.

## Verification

- Opened **Channels → Create Channel Group**.
- Verified the ID field displays the default underline before focus.
- Verified the ID field uses the same focus styling and interaction as the Name and Description fields.
- Verified the maximum input length is limited to 20 characters.
- Verified no regressions in the Create Channel Group dialog.