### PR TITLE
fix: add missing menu button to Inventory page header on mobile (#536)

### DIFF
--- a/src/views/Inventory.vue
+++ b/src/views/Inventory.vue
@@ -2,6 +2,7 @@
   <ion-page>
     <ion-header>
       <ion-toolbar>
+        <ion-menu-button slot="start" />
         <ion-title data-testid="closed-page-title">
           {{ translate("Inventory") }}
         </ion-title>
@@ -195,7 +196,7 @@
 
 <script setup lang="ts">
 import { DxpShopifyImg, emitter, translate } from "@common";
-import { IonButton, IonButtons, IonCard, IonCardContent, IonCheckbox, IonContent, IonFooter, IonHeader, IonIcon, IonItem, IonLabel, IonNote, IonPage, IonSearchbar, IonSegment, IonSegmentButton, IonSelect, IonSelectOption, IonSkeletonText, IonThumbnail, IonTitle, IonToolbar, modalController, onIonViewDidEnter, onIonViewDidLeave } from "@ionic/vue";
+import { IonButton, IonButtons, IonCard, IonCardContent, IonCheckbox, IonContent, IonFooter, IonHeader, IonIcon, IonItem, IonLabel, IonMenuButton, IonNote, IonPage, IonSearchbar, IonSegment, IonSegmentButton, IonSelect, IonSelectOption, IonSkeletonText, IonThumbnail, IonTitle, IonToolbar, modalController, onIonViewDidEnter, onIonViewDidLeave } from "@ionic/vue";
 import { caretBackOutline, caretForwardOutline } from "ionicons/icons";
 import { computed, nextTick, ref, watch } from "vue";
 import LinkThresholdFacilitiesToGroupModal from "@/components/LinkThresholdFacilitiesToGroupModal.vue";

--- a/tests/inventorySelection.test.ts
+++ b/tests/inventorySelection.test.ts
@@ -92,6 +92,7 @@ describe("Inventory product selection", () => {
       IonItem: defineComponent({ name: "IonItem", template: "<div><slot /></div>" }),
       IonLabel: defineComponent({ name: "IonLabel", template: "<label><slot /></label>" }),
       IonList: defineComponent({ name: "IonList", template: "<div><slot /></div>" }),
+      IonMenuButton: defineComponent({ name: "IonMenuButton", template: "<button />" }),
       IonNote: defineComponent({ name: "IonNote", template: "<span><slot /></span>" }),
       IonPage: defineComponent({ name: "IonPage", template: "<section><slot /></section>" }),
       IonSearchbar: defineComponent({ name: "IonSearchbar", template: "<input />" }),


### PR DESCRIPTION
## Related Issue

Closes #536

## Summary

Fixes an issue where the Inventory page did not display the navigation menu button in mobile view, preventing users from opening the side navigation drawer.

## Root Cause

The Inventory page header did not include an `ion-menu-button`, unlike the other application views that support mobile navigation.

## Changes Made

- Added `ion-menu-button` to the Inventory page header.
- Imported `IonMenuButton` from `@ionic/vue`.
- Aligned the Inventory page header with the navigation pattern used across the application.

## Verification

- Verified the menu button is visible on the Inventory page in mobile view.
- Verified tapping the menu button opens the side navigation drawer.
- Verified desktop behavior remains unchanged.
- Verified navigation is consistent with other application pages.