### PR TITLE
Clean up ATP rule scheduler payload and migrate rule action identifiers

### DIFF
--- a/src/components/RuleItem.vue
+++ b/src/components/RuleItem.vue
@@ -189,7 +189,7 @@ async function editThreshold() {
           rule.ruleActions = [{
             "ruleId": props.rule.ruleId,
             "actionTypeEnumId": "ATP_SAFETY_STOCK",
-            "fieldName": "facility-safety-stock",
+            "fieldName": "minimumStock",
             "fieldValue": data.threshold
           }]
         } else {
@@ -251,7 +251,7 @@ async function editSafetyStock() {
           rule.ruleActions = [{
             "ruleId": props.rule.ruleId,
             "actionTypeEnumId": "ATP_SAFETY_STOCK",
-            "fieldName": "facility-safety-stock",
+            "fieldName": "minimumStock",
             "fieldValue": data.safetyStock
           }]
         } else {

--- a/src/components/RuleItem.vue
+++ b/src/components/RuleItem.vue
@@ -189,7 +189,7 @@ async function editThreshold() {
           rule.ruleActions = [{
             "ruleId": props.rule.ruleId,
             "actionTypeEnumId": "ATP_SAFETY_STOCK",
-            "fieldName": "minimumStock",
+            "fieldName": "minimum-stock",
             "fieldValue": data.threshold
           }]
         } else {
@@ -251,7 +251,7 @@ async function editSafetyStock() {
           rule.ruleActions = [{
             "ruleId": props.rule.ruleId,
             "actionTypeEnumId": "ATP_SAFETY_STOCK",
-            "fieldName": "minimumStock",
+            "fieldName": "minimum-stock",
             "fieldValue": data.safetyStock
           }]
         } else {

--- a/src/components/ScheduleActionsPopover.vue
+++ b/src/components/ScheduleActionsPopover.vue
@@ -33,8 +33,7 @@ const ruleGroup = computed(() => ruleStore.getRuleGroup);
 async function disableRuleGroup() {
   const payload = {
     ruleGroupId: ruleGroup.value.ruleGroupId,
-    paused: "Y",
-    systemMessageRemoteId: "RemoteSftp"
+    paused: "Y"
   }
 
   emitter.emit("presentLoader");
@@ -84,9 +83,7 @@ async function runNow() {
             if(!ruleGroup.value.jobName) {
               const payload = {
                 ruleGroupId: ruleGroup.value.ruleGroupId,
-                paused: "Y",  // passing Y as we just need to configure the scheduler and do not need to schedule it in active state
-                // Hardcoding for now, need to fetch system message remote id for the ftp server config.
-                systemMessageRemoteId: "RemoteSftp"
+                paused: "Y" // passing Y as we just need to configure the scheduler and do not need to schedule it in active state
               }
 
               try {

--- a/src/components/ScheduleRuleItem.vue
+++ b/src/components/ScheduleRuleItem.vue
@@ -65,9 +65,7 @@ async function saveSchedule() {
     ruleGroupId: ruleGroup.value.ruleGroupId,
     paused: 'N',
     ...ruleGroup.value,
-    cronExpression: "0 0 0 * * ?",
-    // Hardcoding for now, need to fetch system message remote id for the ftp server config.
-    systemMessageRemoteId: "RemoteSftp"
+    cronExpression: "0 0 0 * * ?"
   }
 
   emitter.emit("presentLoader");

--- a/src/utils/ruleUtil.ts
+++ b/src/utils/ruleUtil.ts
@@ -69,7 +69,7 @@ const generateRuleActions = (ruleId: string, actionTypeEnumId: string, actionVal
 
   let condition;
   if (actionTypeEnumId === "ATP_THRESHOLD" || actionTypeEnumId === "ATP_SAFETY_STOCK") {
-    condition = [{ ruleId, actionTypeEnumId, "fieldName": "minimumStock", "fieldValue": actionValue ? actionValue : 0 }]
+    condition = [{ ruleId, actionTypeEnumId, "fieldName": "minimum-stock", "fieldValue": actionValue ? actionValue : 0 }]
   } else {
     condition = [{ ruleId, actionTypeEnumId, "fieldName": actionTypeEnumId === "ATP_ALLOW_PICKUP" ? "allow-pickup" : "allow-brokering", "fieldValue": actionValue ? "Y" : "N" }]
   }

--- a/src/utils/ruleUtil.ts
+++ b/src/utils/ruleUtil.ts
@@ -69,9 +69,9 @@ const generateRuleActions = (ruleId: string, actionTypeEnumId: string, actionVal
 
   let condition;
   if (actionTypeEnumId === "ATP_THRESHOLD" || actionTypeEnumId === "ATP_SAFETY_STOCK") {
-    condition = [{ ruleId, actionTypeEnumId, "fieldName": "facility-safety-stock", "fieldValue": actionValue ? actionValue : 0 }]
+    condition = [{ ruleId, actionTypeEnumId, "fieldName": "minimumStock", "fieldValue": actionValue ? actionValue : 0 }]
   } else {
-    condition = [{ ruleId, actionTypeEnumId, "fieldName": actionTypeEnumId === "ATP_ALLOW_PICKUP" ? "allow-pickup" : "allow-brokering", "fieldValue": actionValue ? "Y" : "N" }]
+    condition = [{ ruleId, actionTypeEnumId, "fieldName": actionTypeEnumId === "ATP_ALLOW_PICKUP" ? "allowPickup" : "allowBrokering", "fieldValue": actionValue ? "Y" : "N" }]
   }
   return condition
 }

--- a/src/utils/ruleUtil.ts
+++ b/src/utils/ruleUtil.ts
@@ -71,7 +71,7 @@ const generateRuleActions = (ruleId: string, actionTypeEnumId: string, actionVal
   if (actionTypeEnumId === "ATP_THRESHOLD" || actionTypeEnumId === "ATP_SAFETY_STOCK") {
     condition = [{ ruleId, actionTypeEnumId, "fieldName": "minimumStock", "fieldValue": actionValue ? actionValue : 0 }]
   } else {
-    condition = [{ ruleId, actionTypeEnumId, "fieldName": actionTypeEnumId === "ATP_ALLOW_PICKUP" ? "allowPickup" : "allowBrokering", "fieldValue": actionValue ? "Y" : "N" }]
+    condition = [{ ruleId, actionTypeEnumId, "fieldName": actionTypeEnumId === "ATP_ALLOW_PICKUP" ? "allow-pickup" : "allow-brokering", "fieldValue": actionValue ? "Y" : "N" }]
   }
   return condition
 }


### PR DESCRIPTION
Closes: https://github.com/hotwax/order-routing/issues/543

## What
This PR consolidates two frontend updates to align with recent backend DataManager changes:
1. Removes the hardcoded `systemMessageRemoteId: "RemoteSftp"` property from the ATP rule scheduler payload in both `ScheduleActionsPopover.vue` and `ScheduleRuleItem.vue`.
2. Migrates the rule action `fieldName` identifiers to use the native entity property names expected by the Moqui backend DataManager.

## Why
* **Scheduler Payload Cleanup:** In a recent backend update, the ATP inventory export process was completely refactored to use Moqui's native `DataManager` instead of the legacy OFBiz SFTP export flow. As a result, the `systemMessageRemoteId` parameter is no longer accepted or utilized by the `store#RuleGroupSchedule` API or the underlying `run#ExportProductFacilityDetail` export job. Passing this property from the UI was essentially dead code and technically inaccurate, as the OMS API now automatically ignores it. This cleans up the payload to strictly reflect actual backend requirements.
* **Rule Action Identifiers:** The backend DataManager expects native entity property names. By migrating the `fieldName` identifiers on the frontend, we eliminate the need for complex, legacy column-mapping logic in the backend.

## Changes
* **`ScheduleActionsPopover.vue`**: Removed `systemMessageRemoteId` from the payload sent during the `disableRuleGroup()` and `runNow()` actions.
* **`ScheduleRuleItem.vue`**: Removed `systemMessageRemoteId` from the payload sent during the `saveSchedule()` action.
* **Rule Identifiers**: Updated the following `fieldName` properties to match their native backend names:
  * `facility-safety-stock` ➔ `minimum-stock`

*(Note: The other instances of `systemMessageRemoteId` in the codebase belong to the Channel Inventory Shopify integration and were purposefully left intact.)*

## How to Test
Tested the frontend and backend integration locally to ensure the removal of the parameter and updated identifiers do not affect the ability to schedule or run jobs:
1. Create a new ATP rule group without an existing schedule.
2. Verify the **"Run now"** action successfully configures a draft schedule and executes the job immediately without error (API returned `200 OK`).
3. Verify the **"Disable"** action successfully sends the payload with just `paused: "Y"` and is respected by the backend.
4. Confirm that the backend job successfully completes (generating the CSV and DataManager logs) without complaining about missing SFTP config parameters.
5. Create a new Threshold, Safety Stock, Shipping, or Store Pickup rule in the UI.
6. Verify the generated rule payload correctly saves with the new property name for Safety Stock and Threshold Rules (`minimum-stock`) instead of the old legacy name.
