### PR TITLE
Fix dashboard queue summary request

### DIFF
--- a/src/components/DashboardSummary.vue
+++ b/src/components/DashboardSummary.vue
@@ -23,7 +23,7 @@
           </ion-item>
           <ion-item>
             <ion-label>{{ translate("In queue now") }}</ion-label>
-            <ion-label slot="end">{{ routing.queueDepth }}</ion-label>
+            <ion-label slot="end">{{ routing.queueDepth === null ? translate("Unavailable") : routing.queueDepth }}</ion-label>
           </ion-item>
           <ion-item v-if="routing.oldestQueued" lines="none">
             <ion-label class="ion-text-wrap">

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1111,6 +1111,7 @@
   "Unable to update threshold rule.": "Unable to update threshold rule.",
   "Unarchive": "Unarchive",
   "Unarchived": "Unarchived",
+  "Unavailable": "Unavailable",
   "Unavailable items": "Unavailable items",
   "Unavailable items queue": "Unavailable items queue",
   "Unfillable": "Unfillable",

--- a/src/store/dashboardStore.ts
+++ b/src/store/dashboardStore.ts
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import { api, commonUtil, logger } from "@common";
+import { api, commonUtil, logger, useSolrSearch } from "@common";
 import { DateTime } from "luxon";
 import { useAtpProductStore } from "@/store/atpProductStore";
 import { orderRoutingStore } from "@/store/orderRoutingStore";
@@ -84,7 +84,7 @@ export interface RoutingState {
   nextRun: number | null;
   errorCount: number;
   runs: RoutingRun[];
-  queueDepth: number;
+  queueDepth: number | null;
   oldestQueued: OldestQueuedOrder | null;
   totalAttempted: number;
   totalBrokered: number;
@@ -138,33 +138,28 @@ function toMillis(isoDate: string): number | null {
 // Single query serves both the queue size (numFound) and the oldest queued line
 // (docs[0], sorted by orderDate asc). Returns line-item count to match the OMS
 // Find Order page for the same facilities.
-async function fetchQueueSummary(productStoreId: string): Promise<{ count: number; oldest: OldestQueuedOrder | null }> {
+async function fetchQueueSummary(productStoreId: string): Promise<{ count: number; oldest: OldestQueuedOrder | null } | null> {
   try {
-    const response = await api({
-      url: "solr-query",
-      method: "post",
-      baseURL: commonUtil.getOmsURL(),
-      data: {
-        json: {
-          params: {
-            rows: "1",
-            sort: "orderDate asc",
-            fl: "orderId,orderName,customerPartyName,facilityName,orderDate,orderStatusDesc,salesChannelDesc",
-            "q.op": "AND",
-            start: 0
-          },
-          query: "*:*",
-          filter: [
-            "docType: ORDER",
-            "orderTypeId: SALES_ORDER",
-            `facilityId: (${QUEUE_FACILITY_IDS.map(escapeSolrValue).join(" OR ")})`,
-            `productStoreId: ${escapeSolrValue(productStoreId)}`
-          ].join(" AND ")
-        }
+    const response = await useSolrSearch().runSolrQuery({
+      json: {
+        params: {
+          rows: "1",
+          sort: "orderDate asc",
+          fl: "orderId,orderName,customerPartyName,facilityName,orderDate,orderStatusDesc,salesChannelDesc",
+          "q.op": "AND",
+          start: 0
+        },
+        query: "*:*",
+        filter: [
+          "docType: ORDER",
+          "orderTypeId: SALES_ORDER",
+          `facilityId: (${QUEUE_FACILITY_IDS.map(escapeSolrValue).join(" OR ")})`,
+          `productStoreId: ${escapeSolrValue(productStoreId)}`
+        ].join(" AND ")
       }
     }) as any;
 
-    if (commonUtil.hasError(response)) return { count: 0, oldest: null };
+    if (commonUtil.hasError(response)) return null;
 
     const count = Number(response.data?.response?.numFound || 0);
     const doc = response.data?.response?.docs?.[0];
@@ -182,7 +177,7 @@ async function fetchQueueSummary(productStoreId: string): Promise<{ count: numbe
     return { count, oldest };
   } catch (err) {
     logger.error("dashboard: failed to load queue summary", err);
-    return { count: 0, oldest: null };
+    return null;
   }
 }
 
@@ -212,7 +207,7 @@ export const useDashboardStore = defineStore("dashboard", {
     loading: false,
     loadedAt: null,
     sourcing: [],
-    routing: { total: 0, scheduled: 0, paused: 0, draft: 0, nextRun: null, errorCount: 0, runs: [], queueDepth: 0, oldestQueued: null, totalAttempted: 0, totalBrokered: 0, lastRun: null, lastGroupRun: null },
+    routing: { total: 0, scheduled: 0, paused: 0, draft: 0, nextRun: null, errorCount: 0, runs: [], queueDepth: null, oldestQueued: null, totalAttempted: 0, totalBrokered: 0, lastRun: null, lastGroupRun: null },
     facilityOrders: [],
     facilityOrdersDate: null,
     foundations: { facilityGroups: 0, facilityGroupsByType: {}, channels: 0 },
@@ -298,7 +293,7 @@ export const useDashboardStore = defineStore("dashboard", {
     async loadRouting() {
       const routingStore = orderRoutingStore();
       const productStoreId = useAtpProductStore().currentProductStore?.productStoreId;
-      const routing: RoutingState = { total: 0, scheduled: 0, paused: 0, draft: 0, nextRun: null, errorCount: 0, runs: [], queueDepth: 0, oldestQueued: null, totalAttempted: 0, totalBrokered: 0, lastRun: null, lastGroupRun: null };
+      const routing: RoutingState = { total: 0, scheduled: 0, paused: 0, draft: 0, nextRun: null, errorCount: 0, runs: [], queueDepth: null, oldestQueued: null, totalAttempted: 0, totalBrokered: 0, lastRun: null, lastGroupRun: null };
       try {
         await routingStore.fetchOrderRoutingGroups();
         const routingGroups = routingStore.getRoutingGroups || [];
@@ -351,8 +346,8 @@ export const useDashboardStore = defineStore("dashboard", {
 
         if (productStoreId) {
           const queueSummary = await fetchQueueSummary(productStoreId);
-          routing.queueDepth = queueSummary.count;
-          routing.oldestQueued = queueSummary.oldest;
+          routing.queueDepth = queueSummary?.count ?? null;
+          routing.oldestQueued = queueSummary?.oldest ?? null;
         }
       } catch (err) {
         logger.error("dashboard: failed to load routing groups", err);

--- a/src/store/dashboardStore.ts
+++ b/src/store/dashboardStore.ts
@@ -161,8 +161,11 @@ async function fetchQueueSummary(productStoreId: string): Promise<{ count: numbe
 
     if (commonUtil.hasError(response)) return null;
 
-    const count = Number(response.data?.response?.numFound || 0);
-    const doc = response.data?.response?.docs?.[0];
+    const result = response.data?.response;
+    const count = Number(result?.numFound);
+    if (result?.numFound == null || !Number.isFinite(count)) return null;
+
+    const doc = result.docs?.[0];
     const oldest: OldestQueuedOrder | null = doc
       ? {
           orderId: doc.orderId,

--- a/tests/dashboardStore.test.ts
+++ b/tests/dashboardStore.test.ts
@@ -2,7 +2,7 @@ import { createPinia, setActivePinia } from "pinia";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useAtpProductStore } from "@/store/atpProductStore";
 import { useDashboardStore } from "@/store/dashboardStore";
-import { api } from "@common";
+import { api, useSolrSearch } from "@common";
 
 vi.mock("@common", () => ({
   api: vi.fn(),
@@ -11,14 +11,24 @@ vi.mock("@common", () => ({
   },
   logger: {
     error: vi.fn()
-  }
+  },
+  useSolrSearch: vi.fn()
 }));
 
 vi.mock("@/store/userStore", () => ({
   useUserStore: vi.fn(() => ({}))
 }));
 
+vi.mock("@/store/orderRoutingStore", () => ({
+  orderRoutingStore: vi.fn(() => ({
+    fetchOrderRoutingGroups: vi.fn().mockResolvedValue(true),
+    getRoutingGroups: []
+  }))
+}));
+
 const mockedApi = vi.mocked(api);
+const mockedUseSolrSearch = vi.mocked(useSolrSearch);
+const mockedRunSolrQuery = vi.fn();
 
 describe("dashboardStore.loadFoundations", () => {
   beforeEach(() => {
@@ -74,5 +84,61 @@ describe("dashboardStore.loadFoundations", () => {
       facilityGroupsByType: {},
       channels: 0
     });
+  });
+});
+
+describe("dashboardStore.loadRouting", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockedApi.mockReset();
+    mockedRunSolrQuery.mockReset();
+    mockedUseSolrSearch.mockReset();
+    mockedUseSolrSearch.mockReturnValue({ runSolrQuery: mockedRunSolrQuery } as ReturnType<typeof useSolrSearch>);
+  });
+
+  it("loads the queue summary through the backend-aware Solr adapter", async () => {
+    useAtpProductStore().$patch({ currentProductStore: { productStoreId: "STORE" } });
+    mockedRunSolrQuery.mockResolvedValue({
+      data: {
+        response: {
+          numFound: 1874,
+          docs: [{
+            orderId: "M100001",
+            orderName: "100001",
+            customerPartyName: "Test Customer",
+            facilityName: "Brokering Queue",
+            orderDate: "2026-08-12T10:00:00Z",
+            orderStatusDesc: "Approved",
+            salesChannelDesc: "Web Channel"
+          }]
+        }
+      }
+    });
+
+    await useDashboardStore().loadRouting();
+
+    expect(mockedRunSolrQuery).toHaveBeenCalledWith({
+      json: {
+        params: expect.objectContaining({ rows: "1", sort: "orderDate asc" }),
+        query: "*:*",
+        filter: "docType: ORDER AND orderTypeId: SALES_ORDER AND facilityId: (_NA_ OR UNFILLABLE_PARKING OR REJECTED_ITM_PARKING OR RELEASED_ORD_PARKING OR UNF_HOLD_PARKING) AND productStoreId: STORE"
+      }
+    });
+    expect(mockedApi).not.toHaveBeenCalledWith(expect.objectContaining({ url: "solr-query" }));
+    expect(useDashboardStore().getRouting.queueDepth).toBe(1874);
+    expect(useDashboardStore().getRouting.oldestQueued).toEqual(expect.objectContaining({
+      orderId: "M100001",
+      orderName: "100001"
+    }));
+  });
+
+  it("keeps the queue count unavailable when the Solr request fails", async () => {
+    useAtpProductStore().$patch({ currentProductStore: { productStoreId: "STORE" } });
+    mockedRunSolrQuery.mockRejectedValue(new Error("Request failed"));
+
+    await useDashboardStore().loadRouting();
+
+    expect(useDashboardStore().getRouting.queueDepth).toBeNull();
+    expect(useDashboardStore().getRouting.oldestQueued).toBeNull();
   });
 });

--- a/tests/dashboardStore.test.ts
+++ b/tests/dashboardStore.test.ts
@@ -138,6 +138,18 @@ describe("dashboardStore.loadRouting", () => {
 
     await useDashboardStore().loadRouting();
 
+    expect(mockedRunSolrQuery).toHaveBeenCalledTimes(1);
+    expect(useDashboardStore().getRouting.queueDepth).toBeNull();
+    expect(useDashboardStore().getRouting.oldestQueued).toBeNull();
+  });
+
+  it("keeps the queue count unavailable when the Solr response is malformed", async () => {
+    useAtpProductStore().$patch({ currentProductStore: { productStoreId: "STORE" } });
+    mockedRunSolrQuery.mockResolvedValue({ data: {} });
+
+    await useDashboardStore().loadRouting();
+
+    expect(mockedRunSolrQuery).toHaveBeenCalledTimes(1);
     expect(useDashboardStore().getRouting.queueDepth).toBeNull();
     expect(useDashboardStore().getRouting.oldestQueued).toBeNull();
   });


### PR DESCRIPTION
## Summary

- Route the dashboard queue summary through the existing backend-aware Solr adapter.
- Stop converting queue-summary failures or malformed responses into a valid-looking zero; the card now shows **Unavailable** when the metric could not be loaded.
- Add focused coverage for the successful request path, request failure, and malformed response state.

## Evidence

- Issue and approved evidence packet: https://github.com/hotwax/order-routing/issues/548
- The Jam evidence attached to the issue was reviewed before implementation.

## Root cause

dashboardStore.fetchQueueSummary() bypassed the shared Solr adapter by hard-coding a backend route. Its catch block then returned count: 0, masking request failure as real queue data. A missing or invalid numFound response is also now treated as unavailable instead of being coerced to zero.

## Why this layer

This is an Order Routing frontend request-shaping and error-state bug. The working search contract already exists, and AccxUI already provides useSolrSearch().runSolrQuery() to select and normalize the correct backend path.

## Verification

- Focused tests/dashboardStore.test.ts: 5 tests passed.
- Full suite: 50 test files and 291 tests passed.
- Typecheck passed.
- Production Vite build passed.
- git diff --check passed.
- GitHub Verify build passed on Node 20.x and 22.x.
- Authenticated Rails UAT Browser verification passed: the dashboard rendered a nonzero queue summary and oldest queued order, the backend-aware request succeeded, the obsolete request path was not invoked, and no queue-summary console error was logged.

## Risk

Low. The queue filter and response mapping are unchanged; only request routing moves to the established shared adapter. A real zero remains 0, while request failures and malformed responses render Unavailable.

Closes #548