### PR TITLE
Optimize tag search and simplify facility limit override

### DIFF
--- a/src/components/AddInventoryFilterOptionsModal.vue
+++ b/src/components/AddInventoryFilterOptionsModal.vue
@@ -86,6 +86,9 @@ const hiddenOptions = ["IIP_MSMNT_SYSTEM", "IIP_SPLIT_ITEM_GROUP"]
 const dependentOptions = {"ISP_CUST_SEQ": { code: "facilityGroupId", label: "Facility group" }} as any
 // managing this object, as we have some filters for which we need to have its associated filter, like in this case when we have PROXIMITY we also need to add MEASUREMENT_SYSTEM(this is not available on UI for selection and included in hiddenOptions)
 const associatedOptions = { IIP_PROXIMITY: { enum: "IIP_MSMNT_SYSTEM", defaultValue: "IMPERIAL" }} as any
+// This is a presence-based override: selecting it always means bypass the facility order limit.
+// Removing the condition restores the normal limit check.
+const fixedConditionValues = { IFP_IGNORE_ORD_FAC_LIMIT: "Y" } as Record<string, string>
 
 onMounted(() => {
   inventoryRuleConditions.value = props.ruleConditions ? JSON.parse(JSON.stringify(props.ruleConditions)) : {}
@@ -101,6 +104,13 @@ function checkFilters() {
   areFiltersUpdated.value = areFiltersUpdated.value ? areFiltersUpdated.value : Object.keys(props.ruleConditions).some((options: string) => {
     return !inventoryRuleConditions.value[options]
   })
+
+  if (!areFiltersUpdated.value) {
+    areFiltersUpdated.value = enumerations.value.some((condition: any) => {
+      if (!fixedConditionValues[condition.enumId]) return false;
+      return props.ruleConditions?.[condition.enumCode]?.fieldValue !== inventoryRuleConditions.value[condition.enumCode]?.fieldValue;
+    })
+  }
 }
 
 function addConditionOption(condition: any) {
@@ -113,7 +123,10 @@ function addConditionOption(condition: any) {
   } else {
     // checking unchecking an option and then checking it again, we need to use the same values
     if(props.ruleConditions?.[condition.enumCode]) {
-      inventoryRuleConditions.value[condition.enumCode] = props.ruleConditions[condition.enumCode]
+      inventoryRuleConditions.value[condition.enumCode] = {
+        ...props.ruleConditions[condition.enumCode],
+        ...(fixedConditionValues[condition.enumId] ? { fieldValue: fixedConditionValues[condition.enumId] } : {})
+      }
       associatedEnum && (inventoryRuleConditions.value[associatedEnum.enumCode] = props.ruleConditions[associatedEnum.enumCode])
     } else {
       // when adding a new value, we don't need to pass conditionSeqId
@@ -124,7 +137,8 @@ function addConditionOption(condition: any) {
         fieldName: condition.enumCode,
         sequenceNum: Object.keys(inventoryRuleConditions.value).length && inventoryRuleConditions.value[Object.keys(inventoryRuleConditions.value)[Object.keys(inventoryRuleConditions.value).length - 1]]?.sequenceNum >= 0 ? inventoryRuleConditions.value[Object.keys(inventoryRuleConditions.value)[Object.keys(inventoryRuleConditions.value).length - 1]].sequenceNum + 5 : 0,  // added check for `>= 0` as sequenceNum can be 0 which will result in again setting the new seqNum to 0
         createdDate: DateTime.now().toMillis(),
-        operator: condition.enumCode.includes("_excluded") ? "not-equals" : ""
+        operator: condition.enumCode.includes("_excluded") ? "not-equals" : fixedConditionValues[condition.enumId] ? "equals" : "",
+        ...(fixedConditionValues[condition.enumId] ? { fieldValue: fixedConditionValues[condition.enumId] } : {})
       }
 
       // Adding associatedEnum out of ternary, as we will always get the conditionTypeEnumId, as the filter will already handle that
@@ -147,7 +161,11 @@ function saveConditionOptions() {
 }
 
 function isConditionOptionSelected(code: string) {
-  return inventoryRuleConditions.value?.[code]
+  const condition = inventoryRuleConditions.value?.[code]
+  const enumeration = enumerations.value.find((option: any) => option.enumCode === code)
+  if (!fixedConditionValues[enumeration?.enumId]) return condition
+
+  return [true, "Y", "true"].includes(condition?.fieldValue)
 }
 
 function closeModal(action = "close") {

--- a/src/components/AddInventoryFilterOptionsModal.vue
+++ b/src/components/AddInventoryFilterOptionsModal.vue
@@ -114,7 +114,7 @@ function checkFilters() {
 }
 
 function addConditionOption(condition: any) {
-  const isConditionOptionAlreadyApplied = isConditionOptionSelected(condition.enumCode)?.fieldName
+  const isConditionOptionAlreadyApplied = Boolean(isConditionOptionSelected(condition.enumCode))
   const associatedEnum = enums.value[props.parentEnumId][associatedOptions[condition.enumId]?.enum]
   if(isConditionOptionAlreadyApplied) {
     delete inventoryRuleConditions.value[condition.enumCode]

--- a/src/components/AddProductFiltersModal.vue
+++ b/src/components/AddProductFiltersModal.vue
@@ -133,6 +133,7 @@ watch(queryString, (value) => {
     return;
   }
 
+  currentSearchRequestId += 1;
   isLoading.value = true;
   searchTimer = setTimeout(search, SEARCH_DEBOUNCE_MS);
 })

--- a/src/components/AddProductFiltersModal.vue
+++ b/src/components/AddProductFiltersModal.vue
@@ -8,12 +8,11 @@
       </ion-buttons>
       <ion-title>{{ type === "included" ? translate("Include", { label }) : translate("Exclude", { label }) }}</ion-title>
       <ion-buttons slot="end">
-        <!-- Clear all button should be disabled if no facetOptions are available to select or if no filter is selected. -->
-        <ion-button fill="clear" color="danger" :disabled="!facetOptions.length || !selectedValues.length" @click="selectedValues = []">{{ translate("Clear All") }}</ion-button>
+        <ion-button fill="clear" color="danger" :disabled="!selectedValues.length" @click="selectedValues = []">{{ translate("Clear All") }}</ion-button>
       </ion-buttons>
     </ion-toolbar>
     <ion-toolbar>
-      <ion-searchbar :placeholder="translate('Search', { label })" v-model="queryString" @keyup.enter="search()" />
+      <ion-searchbar :placeholder="translate('Search', { label })" v-model="queryString" @keyup.enter="search" />
     </ion-toolbar>
   </ion-header>
 
@@ -96,8 +95,14 @@ const isLoading = ref(false);
 const matchedCount = ref(0);
 const isCountLoading = ref(false);
 let countTimer: any = null;
+let searchTimer: any = null;
 let currentRequestId = 0;
+let currentSearchRequestId = 0;
 let isInitialLoad = true;
+let facetCountsRequested = false;
+
+const SEARCH_DEBOUNCE_MS = 300;
+const SEARCH_RESULT_LIMIT = 100;
 
 const props = defineProps(["label", "facetToSelect", "searchfield", "type"]);
 const productStore = useAtpProductStore();
@@ -105,20 +110,31 @@ const productStore = useAtpProductStore();
 const appliedFilters = computed(() => productStore.getAppliedFilters);
 const appliedFiltersOperator = computed(() => productStore.getAppliedFiltersOperator);
 
-onMounted(async() => {
-  isLoading.value = true;
-  await productStore.fetchProductFilters({ facetToSelect: props.facetToSelect, searchfield: props.searchfield })
-  facetOptions.value = productStore.getFacetOptions(props.searchfield);
-  filteredOptions.value = [...facetOptions.value]
-  // Per-value product counts load independently so the option list isn't blocked on the count query.
-  productStore.fetchProductFacetCounts(props.searchfield).then((counts: Record<string, number>) => { countById.value = counts })
+onMounted(() => {
   selectedValues.value = JSON.parse(JSON.stringify((appliedFilters.value as any)[props.type][props.searchfield]))
-  isLoading.value = false;
-  refreshMatchedCount();
+  void refreshMatchedCount();
 })
 
 onUnmounted(() => {
   if (countTimer) clearTimeout(countTimer);
+  if (searchTimer) clearTimeout(searchTimer);
+})
+
+// Keep the modal cheap to open. Facet options are queried server-side only after the user types,
+// and a short debounce avoids issuing a request for every keystroke.
+watch(queryString, (value) => {
+  if (searchTimer) clearTimeout(searchTimer);
+
+  if (!value.trim()) {
+    currentSearchRequestId += 1;
+    facetOptions.value = [];
+    filteredOptions.value = [];
+    isLoading.value = false;
+    return;
+  }
+
+  isLoading.value = true;
+  searchTimer = setTimeout(search, SEARCH_DEBOUNCE_MS);
 })
 
 // Recompute the live total (debounced) whenever the modal-local selection changes.
@@ -162,14 +178,37 @@ function closeModal() {
   modalController.dismiss({ dismissed: true });
 }
 
-function search() {
-  const searchTerm = queryString.value.trim().toLowerCase();
+async function search() {
+  if (searchTimer) clearTimeout(searchTimer);
+  const searchTerm = queryString.value.trim();
+  if (!searchTerm) return;
 
-  if(searchTerm) {
-    filteredOptions.value = facetOptions.value.filter((option: any) => option.label.toLowerCase().includes(searchTerm))
-  } else {
-    filteredOptions.value = [...facetOptions.value]
+  const requestId = ++currentSearchRequestId;
+  isLoading.value = true;
+  try {
+    const options = await productStore.fetchProductFilters({
+      facetToSelect: props.facetToSelect,
+      searchfield: props.searchfield,
+      queryString: searchTerm,
+      limit: SEARCH_RESULT_LIMIT,
+      maxResults: SEARCH_RESULT_LIMIT
+    })
+    if (requestId !== currentSearchRequestId) return;
+    facetOptions.value = options || [];
+    filteredOptions.value = [...facetOptions.value];
+    loadFacetCounts();
+  } finally {
+    if (requestId === currentSearchRequestId) {
+      isLoading.value = false;
+    }
   }
+}
+
+function loadFacetCounts() {
+  if (facetCountsRequested) return;
+  facetCountsRequested = true;
+  productStore.fetchProductFacetCounts(props.searchfield)
+    .then((counts: Record<string, number>) => { countById.value = counts })
 }
 
 function updateSelectedValues(value: string) {

--- a/src/components/RuleDetails.vue
+++ b/src/components/RuleDetails.vue
@@ -56,11 +56,8 @@
               <ion-label>{{ translate("Safety stock") }}</ion-label>
               <ion-label slot="end">{{ getFilterValue(inventoryRuleFilterOptions, conditionFilterEnums, "BRK_SAFETY_STOCK").fieldValue || getFilterValue(inventoryRuleFilterOptions, conditionFilterEnums, "BRK_SAFETY_STOCK").fieldValue == 0 ? getFilterValue(inventoryRuleFilterOptions, conditionFilterEnums, "BRK_SAFETY_STOCK").fieldValue : "-" }}</ion-label>
             </ion-item>
-            <ion-item v-if="getFilterValue(inventoryRuleFilterOptions, conditionFilterEnums, 'FACILITY_ORDER_LIMIT')">
-              <!-- TODO: for now not changing the UI for this filter, as we need discuss what to display like enabled/disabled, true/false etc-->
-              <ion-toggle :checked="getFilterValue(inventoryRuleFilterOptions, conditionFilterEnums, 'FACILITY_ORDER_LIMIT').fieldValue === 'Y'" disabled>
-                {{ translate("Turn of the facility order limit check") }}
-              </ion-toggle>
+            <ion-item v-if="[true, 'Y', 'true'].includes(getFilterValue(inventoryRuleFilterOptions, conditionFilterEnums, 'FACILITY_ORDER_LIMIT')?.fieldValue)">
+              <ion-label>{{ translate("Override facility order limit") }}</ion-label>
             </ion-item>
           </ion-card>
           <ion-card>

--- a/src/components/circuit/RoutingGroupEditor.vue
+++ b/src/components/circuit/RoutingGroupEditor.vue
@@ -535,11 +535,7 @@
             </ion-item>
 
             <ion-item v-else-if="item.target.endsWith('.FACILITY_ORDER_LIMIT')" :class="{ 'dirty-setting-row': item.dirty }">
-              <ion-toggle :checked="getFilterValue(inventoryRuleFilterOptions, conditionFilterEnums, 'FACILITY_ORDER_LIMIT').fieldValue === 'Y'" @ionChange="updateRuleFilterValue($event, 'FACILITY_ORDER_LIMIT')">
-                <ion-label class="ion-text-wrap">
-                  {{ translate("Turn off the facility order limit check") }}
-                </ion-label>
-              </ion-toggle>
+              <ion-label class="ion-text-wrap">{{ translate("Override facility order limit") }}</ion-label>
             </ion-item>
             <ion-item v-else-if="item.target.endsWith('.SHIP_THRESHOLD')" :class="{ 'dirty-setting-row': item.dirty }">
               <ion-label>{{ translate('Shipment threshold check') }}</ion-label>
@@ -918,7 +914,11 @@ const ruleFiltersSectionCard = computed<RoutingConfigSection>(() => ({
     (code, parameter) => isRuleConditionCodeDirty("ENTCT_FILTER", code)
       || isRuleConditionDirty("ENTCT_FILTER", parameter)
       || (parameter === "PROXIMITY" && isRuleConditionDirty("ENTCT_FILTER", "MEASUREMENT_SYSTEM"))
-  ).filter((item) => !item.target.endsWith(".SPLIT_ITEM_GROUP") && !item.target.endsWith(".MEASUREMENT_SYSTEM"))
+  ).filter((item) => (
+    !item.target.endsWith(".SPLIT_ITEM_GROUP")
+    && !item.target.endsWith(".MEASUREMENT_SYSTEM")
+    && (!item.target.endsWith(".FACILITY_ORDER_LIMIT") || [true, "Y", "true"].includes(getFilterValue(inventoryRuleFilterOptions.value, conditionFilterEnums, "FACILITY_ORDER_LIMIT")?.fieldValue))
+  ))
 }));
 const ruleSortSectionCard = computed<RoutingConfigSection>(() => ({
   key: "canvas:rule:sort",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1104,6 +1104,7 @@
   "Tuesday": "Tuesday",
   "Turn of the facility order limit check": "Turn of the facility order limit check",
   "Turn off the facility order limit check": "Turn off the facility order limit check",
+  "Override facility order limit": "Override facility order limit",
   "Type": "Type",
   "UI Components": "UI Components",
   "Unable to reset the order": "Unable to reset the order",

--- a/src/store/atpProductStore.ts
+++ b/src/store/atpProductStore.ts
@@ -310,10 +310,17 @@ export const useAtpProductStore = defineStore('atpProductStore', {
     },
     async fetchProductFilters(params: any) {
       const filters = JSON.parse(JSON.stringify(this.facetOptions));
-      if (filters[params.searchfield]?.length && !params.queryString) return;
+      if (filters[params.searchfield]?.length && !params.queryString) return filters[params.searchfield];
       let allFacets = [] as any;
       let offset = 0;
       let currentFacets = [];
+      const configuredMax = Number(import.meta.env.VITE_MAX_FACETS);
+      const requestedMax = Number(params.maxResults);
+      const maxResults = Number.isFinite(requestedMax) && requestedMax > 0
+        ? requestedMax
+        : Number.isFinite(configuredMax) && configuredMax > 0 ? configuredMax : 5000;
+      const requestedLimit = Number(params.limit);
+      const limit = Math.min(Number.isFinite(requestedLimit) && requestedLimit > 0 ? requestedLimit : 1000, maxResults);
       try {
         do {
           const payload = {
@@ -322,7 +329,7 @@ export const useAtpProductStore = defineStore('atpProductStore', {
             coreName: 'enterpriseSearch',
             jsonQuery: '{"query":"*:*","filter":["docType:PRODUCT"]}',
             noConditionFind: 'Y',
-            limit: 1000,
+            limit,
             offset,
             searchfield: params.searchfield,
             term: params.queryString || "",
@@ -335,17 +342,22 @@ export const useAtpProductStore = defineStore('atpProductStore', {
           }) as any;
           if (resp && !commonUtil.hasError(resp)) {
             currentFacets = resp.data.facetResponse ? resp.data.facetResponse.response : resp.data.response
-            allFacets = allFacets.concat(currentFacets)
+            allFacets = allFacets.concat(currentFacets).slice(0, maxResults)
             offset = offset + payload.limit
           } else {
             throw resp.data;
           }
-        } while (currentFacets.length && allFacets.length < (import.meta.env.VITE_MAX_FACETS as any))
+        } while (currentFacets.length === limit && allFacets.length < maxResults)
       } catch (error) {
         logger.error(error);
       }
-      filters[params.searchfield] = allFacets
-      this.facetOptions = filters;
+      // Search results are intentionally not cached as the complete facet list. Otherwise a later
+      // unfiltered request could incorrectly reuse the first capped search result.
+      if (!params.queryString) {
+        filters[params.searchfield] = allFacets
+        this.facetOptions = filters;
+      }
+      return allFacets;
     },
     // Per-value product counts for a facet field (e.g. how many products carry each tag), via a Solr
     // terms facet. The admin/solrFacets options response only carries id/label/value, not counts.

--- a/src/utils/draftUtils.ts
+++ b/src/utils/draftUtils.ts
@@ -560,8 +560,9 @@ function addOperation(
 // for new:* rules (no current state to compare against) and for any target whose
 // shape isn't represented in the rule's currentValues snapshot.
 function getRuleCurrentValue(manifest: PageCapabilityManifest, ruleKey: string, target: string): DraftValue | undefined {
+  const defaultValue = target === "selectedRule.inventoryFilters.FACILITY_ORDER_LIMIT" ? false : undefined;
   if (ruleKey.startsWith("new:")) {
-    return undefined;
+    return defaultValue;
   }
 
   const rules = (manifest.visibleEntities as any)?.route?.availableInventoryRules;
@@ -603,7 +604,7 @@ function getRuleCurrentValue(manifest: PageCapabilityManifest, ruleKey: string, 
 
   if (target.startsWith("selectedRule.inventoryFilters.")) {
     const filter = (currentValues.inventoryFilters || []).find((entry: any) => entry?.target === target);
-    return filter ? (filter.value as DraftValue) : undefined;
+    return filter ? (filter.value as DraftValue) : defaultValue;
   }
 
   if (target.startsWith("selectedRule.inventorySorts.")) {

--- a/src/utils/routingConfigSection.ts
+++ b/src/utils/routingConfigSection.ts
@@ -16,7 +16,7 @@ const settingLabels: Record<string, string> = {
   PROXIMITY: "Proximity",
   MEASUREMENT_SYSTEM: "Measurement unit",
   BRK_SAFETY_STOCK: "Safety stock",
-  FACILITY_ORDER_LIMIT: "Facility order limit",
+  FACILITY_ORDER_LIMIT: "Override facility order limit",
   SHIP_THRESHOLD: "Shipment threshold",
   WOS: "Week of supply",
   QUEUE: "Queue",

--- a/src/utils/routingRulesManifest.ts
+++ b/src/utils/routingRulesManifest.ts
@@ -152,8 +152,8 @@ const inventoryFilterDefinitions: FilterDefinition[] = [
   { key: "BRK_SAFETY_STOCK", label: "Brokering safety stock filter", valueType: "number" },
   {
     key: "FACILITY_ORDER_LIMIT",
-    label: "Facility order limit check",
-    description: "Controls whether this rule respects facility order limits. Set false to enforce store caps and protect stores. Set true only when the user explicitly asks to turn off, ignore, or bypass facility order limits.",
+    label: "Override facility order limit",
+    description: "Adds or removes the rule-level override. When present, this rule bypasses facility order limits; when absent, normal facility order limits apply.",
     aliases: ["store cap", "store caps", "store usage cap", "protect stores", "facility order limit", "order limit check"],
     valueType: "boolean",
     options: facilityOrderLimitOptions()
@@ -498,7 +498,11 @@ function applyActiveRuleOperation(operation: DraftOperation, draft: RoutingRules
 
   const inventoryFilterKey = getTargetKey(operation.target, "selectedRule.inventoryFilters.");
   if (inventoryFilterKey) {
-    setConditionOption(draft.inventoryRuleFilterOptions.value, draft.conditionFilterEnums, inventoryFilterKey, operation.value as DraftValue, "ENTCT_FILTER", draft.selectedRoutingRule.value.routingRuleId, "routingRuleId");
+    if (inventoryFilterKey === "FACILITY_ORDER_LIMIT" && !Boolean(operation.value)) {
+      delete draft.inventoryRuleFilterOptions.value[draft.conditionFilterEnums.FACILITY_ORDER_LIMIT.code];
+    } else {
+      setConditionOption(draft.inventoryRuleFilterOptions.value, draft.conditionFilterEnums, inventoryFilterKey, operation.value as DraftValue, "ENTCT_FILTER", draft.selectedRoutingRule.value.routingRuleId, "routingRuleId");
+    }
     if (inventoryFilterKey === "PROXIMITY" && !draft.inventoryRuleFilterOptions.value[draft.conditionFilterEnums.MEASUREMENT_SYSTEM.code]) {
       setConditionOption(draft.inventoryRuleFilterOptions.value, draft.conditionFilterEnums, "MEASUREMENT_SYSTEM", "IMPERIAL", "ENTCT_FILTER", draft.selectedRoutingRule.value.routingRuleId, "routingRuleId");
     }
@@ -1172,11 +1176,11 @@ export function getConditionValue(options: Record<string, ConditionOption>, enum
 
 function getTypedConditionValue(options: Record<string, ConditionOption>, enums: Record<string, EnumInfo>, definition: FilterDefinition): DraftValue | undefined {
   const value = getConditionValue(options, enums, definition.key);
-  if (definition.valueType !== "boolean" || value === undefined) {
+  if (definition.valueType !== "boolean") {
     return value;
   }
 
-  return parseBooleanOption(value);
+  return value === undefined ? false : parseBooleanOption(value);
 }
 
 function parseBooleanOption(value: DraftValue) {

--- a/tests/addInventoryFilterOptionsModal.test.ts
+++ b/tests/addInventoryFilterOptionsModal.test.ts
@@ -1,0 +1,114 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { defineComponent } from "vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ dismiss: vi.fn() }));
+
+vi.mock("@common", () => ({
+  translate: (label: string) => label,
+}));
+
+vi.mock("@/store/utilStore", () => ({
+  useUtilStore: () => ({
+    getEnums: {
+      INV_FILTER_PRM_TYPE: {
+        IFP_IGNORE_ORD_FAC_LIMIT: {
+          enumId: "IFP_IGNORE_ORD_FAC_LIMIT",
+          enumCode: "ignoreFacilityOrderLimit",
+          description: "Override facility order limit",
+        },
+      },
+    },
+  }),
+}));
+
+vi.mock("@ionic/vue", () => ({
+  IonButton: defineComponent({ template: "<button><slot /></button>" }),
+  IonButtons: defineComponent({ template: "<div><slot /></div>" }),
+  IonCheckbox: defineComponent({
+    emits: ["ionChange"],
+    template: '<button class="condition" @click="$emit(\'ionChange\')"><slot /></button>',
+  }),
+  IonContent: defineComponent({ template: "<main><slot /></main>" }),
+  IonFab: defineComponent({ template: "<div><slot /></div>" }),
+  IonFabButton: defineComponent({ template: '<button class="save"><slot /></button>' }),
+  IonHeader: defineComponent({ template: "<header><slot /></header>" }),
+  IonIcon: defineComponent({ template: "<span />" }),
+  IonItem: defineComponent({ template: "<div><slot /></div>" }),
+  IonLabel: defineComponent({ template: "<span><slot /></span>" }),
+  IonList: defineComponent({ template: "<div><slot /></div>" }),
+  IonNote: defineComponent({ template: "<span><slot /></span>" }),
+  IonPage: defineComponent({ template: "<div><slot /></div>" }),
+  IonTitle: defineComponent({ template: "<h1><slot /></h1>" }),
+  IonToolbar: defineComponent({ template: "<div><slot /></div>" }),
+  modalController: { dismiss: mocks.dismiss },
+}));
+
+import AddInventoryFilterOptionsModal from "@/components/AddInventoryFilterOptionsModal.vue";
+
+describe("AddInventoryFilterOptionsModal", () => {
+  beforeEach(() => {
+    mocks.dismiss.mockReset();
+  });
+
+  it("stores the facility order limit override as a fixed true condition", async () => {
+    const wrapper = mount(AddInventoryFilterOptionsModal, {
+      props: {
+        routingRuleId: "RULE-1",
+        ruleConditions: {},
+        parentEnumId: "INV_FILTER_PRM_TYPE",
+        conditionTypeEnumId: "ENTCT_FILTER",
+        label: "Filters",
+        filterOptions: {},
+      },
+    });
+    await flushPromises();
+
+    await wrapper.get("button.condition").trigger("click");
+    await wrapper.get("button.save").trigger("click");
+
+    expect(mocks.dismiss).toHaveBeenCalledWith({
+      dismissed: true,
+      filters: {
+        ignoreFacilityOrderLimit: expect.objectContaining({
+          routingRuleId: "RULE-1",
+          conditionTypeEnumId: "ENTCT_FILTER",
+          fieldName: "ignoreFacilityOrderLimit",
+          fieldValue: "Y",
+          operator: "equals",
+        }),
+      },
+    }, "save");
+  });
+
+  it("normalizes a legacy false row to the presence-based override when selected", async () => {
+    const wrapper = mount(AddInventoryFilterOptionsModal, {
+      props: {
+        routingRuleId: "RULE-1",
+        ruleConditions: {
+          ignoreFacilityOrderLimit: {
+            routingRuleId: "RULE-1",
+            conditionTypeEnumId: "ENTCT_FILTER",
+            fieldName: "ignoreFacilityOrderLimit",
+            fieldValue: "N",
+            operator: "equals",
+          },
+        },
+        parentEnumId: "INV_FILTER_PRM_TYPE",
+        conditionTypeEnumId: "ENTCT_FILTER",
+        label: "Filters",
+        filterOptions: {},
+      },
+    });
+    await flushPromises();
+
+    await wrapper.get("button.condition").trigger("click");
+    await wrapper.get("button.save").trigger("click");
+
+    expect(mocks.dismiss).toHaveBeenCalledWith(expect.objectContaining({
+      filters: {
+        ignoreFacilityOrderLimit: expect.objectContaining({ fieldValue: "Y" }),
+      },
+    }), "save");
+  });
+});

--- a/tests/addProductFiltersModal.test.ts
+++ b/tests/addProductFiltersModal.test.ts
@@ -1,6 +1,6 @@
 import { flushPromises, mount } from "@vue/test-utils";
 import { defineComponent, nextTick } from "vue";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("AddProductFiltersModal", () => {
   const fetchProductFilters = vi.fn();
@@ -14,8 +14,11 @@ describe("AddProductFiltersModal", () => {
 
   beforeEach(() => {
     vi.resetModules();
+    vi.useFakeTimers();
     fetchProductFilters.mockReset();
-    fetchProductFilters.mockResolvedValue(undefined);
+    fetchProductFilters.mockImplementation(async ({ queryString }: { queryString: string }) => (
+      facetOptions.filter((option) => option.label.includes(queryString))
+    ));
     fetchProductFacetCounts.mockReset();
     fetchProductFacetCounts.mockResolvedValue({ "Size/L": 4, "Size/XL": 2 });
     previewProducts.mockReset();
@@ -69,7 +72,11 @@ describe("AddProductFiltersModal", () => {
     }));
   });
 
-  it("filters loaded feature options without refetching from Solr", async () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("opens without prefetching facets and searches the server after typing", async () => {
     const { default: AddProductFiltersModal } = await import("../src/components/AddProductFiltersModal.vue");
     const wrapper = mount(AddProductFiltersModal, {
       props: {
@@ -83,16 +90,24 @@ describe("AddProductFiltersModal", () => {
     await flushPromises();
     await nextTick();
 
-    expect(fetchProductFilters).toHaveBeenCalledTimes(1);
-    expect(wrapper.text()).toContain("Size/L");
-    expect(wrapper.text()).toContain("Size/XL");
+    expect(fetchProductFilters).not.toHaveBeenCalled();
+    expect(fetchProductFacetCounts).not.toHaveBeenCalled();
+    expect(wrapper.text()).not.toContain("Size/L");
 
     const searchbar = wrapper.find("input");
     await searchbar.setValue("Size/XL");
-    await searchbar.trigger("keyup", { key: "Enter" });
-    await nextTick();
+    await vi.advanceTimersByTimeAsync(300);
+    await flushPromises();
 
     expect(fetchProductFilters).toHaveBeenCalledTimes(1);
+    expect(fetchProductFilters).toHaveBeenCalledWith({
+      facetToSelect: "productFeaturesFacet",
+      searchfield: "productFeatures",
+      queryString: "Size/XL",
+      limit: 100,
+      maxResults: 100,
+    });
+    expect(fetchProductFacetCounts).toHaveBeenCalledTimes(1);
     expect(wrapper.text()).toContain("Size/XL");
     expect(wrapper.text()).not.toContain("Size/L");
     expect(wrapper.text()).not.toContain("Color/Blue");

--- a/tests/brokeringRulesDraftTargets.test.ts
+++ b/tests/brokeringRulesDraftTargets.test.ts
@@ -405,7 +405,7 @@ const queueFacilities = {
   assert.equal(secondRule.currentValues.partialGroupedItemAllocation, false);
   assert.deepEqual(secondRule.currentValues.inventoryFilters, [{
     target: "selectedRule.inventoryFilters.FACILITY_ORDER_LIMIT",
-    label: "Facility order limit check",
+    label: "Override facility order limit",
     value: false,
     valueLabel: "Respect facility order limits",
     operator: "equals",
@@ -516,7 +516,7 @@ const queueFacilities = {
   const respectLimits = facilityOrderLimitTarget?.options?.find((option) => option.id === "false");
   const bypassLimits = facilityOrderLimitTarget?.options?.find((option) => option.id === "true");
 
-  assert.equal(facilityOrderLimitTarget?.label, "Facility order limit check");
+  assert.equal(facilityOrderLimitTarget?.label, "Override facility order limit");
   assert.ok(respectLimits?.aliases?.includes("cap store usage"));
   assert.ok(respectLimits?.aliases?.includes("protect stores"));
   assert.ok(bypassLimits?.aliases?.includes("bypass facility order limits"));
@@ -534,7 +534,7 @@ const queueFacilities = {
 {
   const { draft, result } = apply([{ op: "set", target: "selectedRule.inventoryFilters.FACILITY_ORDER_LIMIT", value: "cap store usage" }]);
   assert.equal(result.appliedCount, 1);
-  assert.equal(draft.inventoryRuleFilterOptions.value.ignoreFacilityOrderLimit.fieldValue, "N");
+  assert.equal(draft.inventoryRuleFilterOptions.value.ignoreFacilityOrderLimit, undefined);
   assert.equal(draft.hasUnsavedChanges.value, true);
 }
 

--- a/tests/draftAssistantService.test.ts
+++ b/tests/draftAssistantService.test.ts
@@ -332,7 +332,7 @@ function validate(operations: DraftOperation[]) {
       },
       {
         target: "selectedRule.inventoryFilters.FACILITY_ORDER_LIMIT",
-        label: "Facility order limit check",
+        label: "Override facility order limit",
         valueType: "boolean",
         currentValue: true,
         options: [
@@ -426,7 +426,6 @@ function validate(operations: DraftOperation[]) {
     ["route.orderSorts.SHIP_BY", true],
     ["selectedRule.inventoryFilters.FACILITY_GROUP", "STORES"],
     ["selectedRule.inventoryFilters.FACILITY_GROUP_EXCLUDED", "WAREHOUSES"],
-    ["selectedRule.inventoryFilters.FACILITY_ORDER_LIMIT", false],
     ["selectedRule.inventorySorts.PROXIMITY", true],
     ["selectedRule.unavailableItemsAction", "ORA_MV_TO_QUEUE"],
     ["selectedRule.unavailableItemsQueueId", "UNFILLABLE_PARKING"]

--- a/tests/productFilterSearchStore.test.ts
+++ b/tests/productFilterSearchStore.test.ts
@@ -1,0 +1,55 @@
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "@common";
+import { useAtpProductStore } from "@/store/atpProductStore";
+
+vi.mock("@common", () => ({
+  api: vi.fn(),
+  commonUtil: { hasError: (response: any) => Boolean(response?.error) },
+  logger: { error: vi.fn() },
+}));
+
+vi.mock("@/store/userStore", () => ({
+  useUserStore: vi.fn(() => ({})),
+}));
+
+const mockedApi = vi.mocked(api);
+
+describe("product filter facet search", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockedApi.mockReset();
+  });
+
+  it("returns one capped server-side search page without caching it as the complete facet list", async () => {
+    const facets = Array.from({ length: 150 }, (_, index) => ({
+      id: `tag-${index}`,
+      label: `tag-${index}`,
+      value: `tag-${index}`,
+    }));
+    mockedApi.mockResolvedValue({ data: { response: facets } } as any);
+
+    const store = useAtpProductStore();
+    const result = await store.fetchProductFilters({
+      facetToSelect: "tagsFacet",
+      searchfield: "tags",
+      queryString: "vip",
+      limit: 100,
+      maxResults: 100,
+    });
+
+    expect(mockedApi).toHaveBeenCalledTimes(1);
+    expect(mockedApi).toHaveBeenCalledWith(expect.objectContaining({
+      url: "admin/solrFacets",
+      method: "GET",
+      params: expect.objectContaining({
+        term: "vip",
+        q: "vip",
+        limit: 100,
+        offset: 0,
+      }),
+    }));
+    expect(result).toHaveLength(100);
+    expect(store.getFacetOptions("tags")).toEqual([]);
+  });
+});

--- a/tests/routingGroupEditorUiContracts.test.ts
+++ b/tests/routingGroupEditorUiContracts.test.ts
@@ -93,6 +93,14 @@ describe("routing group editor UI contracts", () => {
     expect(editorSource).toContain(':dirty="isRuleConditionCardDirty(\'ENTCT_FILTER\')"');
   });
 
+  it("renders the facility order limit override as presence-based read-only text", () => {
+    const overrideRow = editorSource.match(/<ion-item v-else-if="item\.target\.endsWith\('\.FACILITY_ORDER_LIMIT'\)"[\s\S]*?<\/ion-item>/)?.[0] || "";
+
+    expect(overrideRow).toContain('translate("Override facility order limit")');
+    expect(overrideRow).not.toContain("ion-toggle");
+    expect(overrideRow).not.toContain("updateRuleFilterValue");
+  });
+
   it("uses the AccxUI single-step modal and list-divider structure for variation differences", () => {
     expect(variationDiffModalSource.match(/<ion-toolbar>/g)).toHaveLength(2);
     expect(variationDiffModalSource).toContain('<ion-icon slot="icon-only" :icon="closeOutline" />');


### PR DESCRIPTION
## Summary

- open the product tag/feature picker without eagerly loading every facet
- query facets only after the user types, with debounce, bounded results, and stale-response protection
- treat **Override facility order limit** as a presence-based boolean and render it as a fixed item instead of a configurable toggle
- normalize legacy false-like override values while preserving save/delete semantics

## Why

Large tag catalogs caused the modal to block while prefetching all facet values. The facility-order-limit override also exposed a toggle even though the backend contract is binary by condition presence: adding the condition enables the override and removing it disables the override.

## Impact

- the tags modal renders immediately and only requests matching values on search
- search results are capped at 100 and do not overwrite the cached complete-list state
- the facility override no longer presents a state that resets after save
- existing legacy false values remain hidden until the override is explicitly selected

## Verification

- `pnpm test -- --run`: 55 files, 313 tests passed
- `pnpm typecheck`: passed
- `pnpm exec vite build`: passed
- authenticated local UI: verified the tags modal opens in an empty search state and transitions after input
- authenticated local UI: staged a routing group entirely in browser memory, added the override, and verified the rendered row contains no toggle; the group was not saved to the backend
- Jam video: https://jam.dev/c/94fb45dc-5073-41e8-b91a-c8e8332c8302
