### PR TITLE
Fixed: repoint inventory history to the scoped inventoryDetail endpoint

### DIFF
--- a/src/composables/useProductFacility.ts
+++ b/src/composables/useProductFacility.ts
@@ -76,14 +76,20 @@ export function useProductFacility() {
     }
   }
 
+  // productId/facilityId are path segments, not query params. The backend dropped the unscoped
+  // GET oms/inventoryItem/detail resource so InventoryItemDetail can never be scanned unfiltered;
+  // both segments now scope the query server-side. The rows come from the InventoryItemDetailAndOrder
+  // view, a strict superset of the old one (adds orderTypeId/orderName/orderDate/orderStatusId), so
+  // every existing consumer of these rows is unaffected.
   async function fetchInventoryLogs(params: { productId: string, facilityId: string, pageSize: any }) {
     const requestId = ++inventoryLogsRequestId
+    const { productId, facilityId, ...query } = params
     try {
       const resp = await api({
-        url: "oms/inventoryItem/detail",
+        url: `oms/products/${encodeURIComponent(productId)}/facilities/${encodeURIComponent(facilityId)}/inventoryDetail`,
         method: "GET",
         params: {
-          ...params,
+          ...query,
           orderByField: "effectiveDate desc"
         }
       })

--- a/src/utils/inventoryMovement.ts
+++ b/src/utils/inventoryMovement.ts
@@ -13,10 +13,11 @@ import {
 import { buildAppUrl } from "@common";
 
 /**
- * Decodes a raw InventoryItemDetail row (from oms/inventoryItem/detail) into a classified
- * "movement" that explains WHICH record impacted inventory — a sales order reservation/shipment,
- * a transfer order, a purchase receipt, a return, a cycle-count variance, an item rollover, the
- * initial receipt, or a manual adjustment.
+ * Decodes a raw InventoryItemDetail row (from the inventory-history endpoint,
+ * oms/products/{productId}/facilities/{facilityId}/inventoryDetail) into a classified "movement"
+ * that explains WHICH record impacted inventory — a sales order reservation/shipment, a transfer
+ * order, a purchase receipt, a return, a cycle-count variance, an item rollover, the initial
+ * receipt, or a manual adjustment.
  *
  * The raw row only carries reference ids (orderId, physicalInventoryId, returnId, …) plus the
  * ATP/QOH/accounting deltas. Order *type* (sales vs transfer vs purchase) is not on the row, so the

--- a/tests/inventoryMovementDeltas.test.ts
+++ b/tests/inventoryMovementDeltas.test.ts
@@ -7,7 +7,7 @@ const passthrough = (name: string) => defineComponent({
   template: "<div><slot name='start' /><slot name='header' /><slot /><slot name='end' /><slot name='content' /></div>",
 });
 
-// Regression coverage for issue #469: the oms/inventoryItem/detail API never returns
+// Regression coverage for issue #469: the inventory-history API never returns
 // lastAvailableToPromise/lastQuantityOnHand, so the ATP/QOH delta pills must show the
 // signed change only, never a fabricated "0 -> diff" total built from a fake 0 baseline.
 describe("InventoryDetail movement deltas (location scope)", () => {

--- a/tests/useProductFacility.test.ts
+++ b/tests/useProductFacility.test.ts
@@ -70,3 +70,44 @@ describe("useProductFacility request ordering", () => {
     );
   });
 });
+
+// The backend removed the unscoped GET oms/inventoryItem/detail resource; inventory history is now
+// only reachable through a mandatorily scoped path. productId/facilityId must therefore travel as
+// path segments — sending them as query params against the old URL now 404s.
+describe("useProductFacility inventory history endpoint", () => {
+  beforeEach(() => {
+    mocks.api.mockReset();
+    mocks.loggerError.mockReset();
+  });
+
+  it("requests the product/facility scoped inventoryDetail path", async () => {
+    mocks.api.mockResolvedValueOnce({ data: [] });
+
+    const productFacilityApi = useProductFacility();
+    await productFacilityApi.fetchInventoryLogs({
+      productId: "SKU_1",
+      facilityId: "CENTRAL_WAREHOUSE",
+      pageSize: 250,
+    });
+
+    expect(mocks.api).toHaveBeenCalledWith({
+      url: "oms/products/SKU_1/facilities/CENTRAL_WAREHOUSE/inventoryDetail",
+      method: "GET",
+      params: { pageSize: 250, orderByField: "effectiveDate desc" },
+    });
+  });
+
+  it("encodes ids that are not URL safe", async () => {
+    mocks.api.mockResolvedValueOnce({ data: [] });
+
+    const productFacilityApi = useProductFacility();
+    await productFacilityApi.fetchInventoryLogs({
+      productId: "SKU/1",
+      facilityId: "WH 2",
+      pageSize: 10,
+    });
+
+    const { url } = mocks.api.mock.calls[0][0];
+    expect(url).toBe("oms/products/SKU%2F1/facilities/WH%202/inventoryDetail");
+  });
+});


### PR DESCRIPTION
## Why

The OMS removed the unscoped `GET oms/inventoryItem/detail` resource so the `InventoryItemDetail` table can never be scanned unfiltered. Inventory history is now only reachable through a mandatorily scoped path, so the app's existing call 404s against any instance running the new build.

Backend change: `hotwax/maarg-oms` `99ff9f08` — *"Added: OrderHeader join to inventory-item-detail endpoint for server-side history filtering (#732)"*, merged to `main` and tagged `v3.1.4` / `v3.1.5`.

## What changed

`fetchInventoryLogs` now calls:

```
oms/products/{productId}/facilities/{facilityId}/inventoryDetail
```

`productId` / `facilityId` move from query params to path segments; `pageSize` and `orderByField` stay as query params. Nothing else about the call changed.

Rows now come from the `InventoryItemDetailAndOrder` view — a **strict superset** of the previous `InventoryItemAndDetail` (additive only: `orderTypeId`, `orderName`, `orderDate`, `orderStatusId`). Every field the movement classifier reads (`physicalInventoryId`, `workEffortId`, `reasonEnumId`, `returnId`, `orderId`, `shipmentId`, `inventoryItemDetailSeqId`) is still present, so row handling in `inventoryMovement.ts` and `InventoryDetail.vue` is unaffected.

Also refreshed two stale comments that named the old path, and added regression coverage for the URL shape (including id encoding).

## Verified against the live contract

Read from the deployed rails-oms Swagger (`https://rails-oms.hotwax.io/rest/service.swagger/oms`), not from local source:

- `/products/{productId}/facilities/{facilityId}/inventoryDetail` — present, path params `productId` + `facilityId`, returns `InventoryItemDetailAndOrder`
- `/inventoryItem/{inventoryItemId}/detail` — present (the by-item access path; not what this view needs)
- `/inventoryItem/detail` — **gone**
- Query params confirmed still accepted: `pageSize`, `pageIndex`, `orderByField`, `pageNoLimit`

## Validation

- `npx vitest run tests/useProductFacility.test.ts tests/inventoryMovementDeltas.test.ts tests/inventoryDetailChannelScope.test.ts tests/inventorySelection.test.ts` — 9/9 pass (2 new)
- `pnpm typecheck` — no errors in any changed file (the only failures are pre-existing, in the sibling `common/cache/sync/appCacheBootstrap.ts` workspace package)
- `npx eslint` — 0 errors on both files whose code changed; the other two diffs are comment-only, so this PR adds no lint debt

Not verified in a running browser: the app would need to be pointed at an OMS on ≥ v3.1.4 to exercise the new path end to end.

## Heads-up

**`dev-maarg` has not picked this up yet.** Its Swagger still serves the old `/inventoryItem/detail` and lacks both new paths, so inventory history will break there once this merges, until that instance is upgraded to ≥ v3.1.4.

## Follow-up (not in this PR)

The OrderHeader join exists to unblock #467 — server-side pagination and date/type filtering, and dropping the separate `fetchOrderSummaries` round-trip now that `orderTypeId` / `orderName` / `orderDate` ride on the row. This PR is only the contract repoint; #467 remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
